### PR TITLE
Set pydocstringformatter max-line-length to 75

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,8 @@ terminal.error-on-warning = true
 [tool.pydocstringformatter]
 write = true
 split-summary-body = false
-max-line-length = 88
+max-line-length = 75
+linewrap-full-docstring = true
 
 [tool.interrogate]
 fail-under = 100


### PR DESCRIPTION
Closes #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that only affects docstring formatting output.
> 
> **Overview**
> Updates `pydocstringformatter` configuration in `pyproject.toml` by reducing `max-line-length` from 88 to 75 and enabling `linewrap-full-docstring`, changing how docstrings are auto-wrapped during formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef07ecdd936aa3f679222b323eb5ff104f40cd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->