### PR TITLE
Add shellcheck-py comment in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ optional-dependencies.dev = [
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "ruff==0.15.4",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx==9.1.0",


### PR DESCRIPTION
Closes #17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a comment-only change in `pyproject.toml` with no runtime or dependency behavior changes.
> 
> **Overview**
> Adds a short comment in `pyproject.toml` explaining that `shellcheck-py` is included not just for shell scripts/code blocks, but also so `actionlint-py` can lint shell commands in GitHub workflow files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f158f4edc91da51bd2f6dff35f49e7606aecbb78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->