### PR TITLE
Change project urls format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
 ]
 optional-dependencies.release = ["check-wheel-contents==0.6.3"]
-urls = { Homepage = "https://github.com/adamtheturtle/wiremock-mock", Documentation = "https://adamtheturtle.github.io/wiremock-mock/" }
+urls.Documentation = "https://adamtheturtle.github.io/wiremock-mock/"
+urls.Source = "https://github.com/adamtheturtle/wiremock-mock"
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
Closes #6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change in `pyproject.toml` that should only affect how package links are published/displayed, not runtime behavior.
> 
> **Overview**
> Updates `pyproject.toml` project metadata to use the PEP 621 dotted `urls.*` keys instead of the inline `urls = { ... }` table, renaming `Homepage` to `Source` while keeping `Documentation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69941508df518f5ad4dd7d1d961ae5c48b938fae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->