### PR TITLE
Add zizmor to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ optional-dependencies.dev = [
     "types-requests>=2.32.0",
     "vulture==2.14",
     "yamlfix==1.19.1",
+    "zizmor==1.22.0",
 ]
 optional-dependencies.release = ["check-wheel-contents==0.6.3"]
 urls.Documentation = "https://adamtheturtle.github.io/wiremock-mock/"


### PR DESCRIPTION
Closes #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new pinned dev-only dependency and does not change runtime code or behavior.
> 
> **Overview**
> Adds `zizmor==1.22.0` to the `optional-dependencies.dev` list in `pyproject.toml`, making the tool available in the development dependency set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3e2288e684149841a024c929c6c8ee886c92de0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->