### PR TITLE
Add setuptools_scm version_scheme and distutils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,16 @@ zip-safe = false
 package-data.wiremock_mock = ["py.typed"]
 packages.find.where = ["src"]
 
+[tool.distutils]
+bdist_wheel.universal = true
+
 [tool.setuptools_scm]
-fallback_version = "0.0.0"
+# This keeps the start of the version the same as the last release.
+# This is useful for our documentation to include e.g. binary links
+# to the latest released binary.
+#
+# Code to match this is in ``conf.py``.
+version_scheme = "post-release"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
Closes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/packaging-only change, but it alters version strings produced by `setuptools_scm` and how wheels are built, which could affect release artifacts and downstream consumers.
> 
> **Overview**
> Updates `pyproject.toml` packaging settings by enabling *universal* wheel builds via `[tool.distutils]` and changing `setuptools_scm` versioning to use `version_scheme = "post-release"` (removing the previous `fallback_version`).
> 
> This primarily affects how distribution artifacts are named/versioned for releases and documentation links, without changing runtime code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5ff15e9d5015f72d5ba7c4a276018cdd1c4ac26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->