### PR TITLE
Update conftest: add DocTestParser and *.py pattern

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,11 @@
 """Pytest configuration with Sybil for doc testing."""
 
+from doctest import ELLIPSIS
+
 import pytest
 from beartype import beartype
 from sybil import Sybil
-from sybil.parsers.codeblock import PythonCodeBlockParser
+from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -13,7 +15,12 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
             item.obj = beartype(obj=item.obj)
 
 
-pytest_collect_file = Sybil(
-    parsers=[PythonCodeBlockParser()],
-    pattern="*.rst",
-).pytest()
+sybil = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS),
+        PythonCodeBlockParser(),
+    ],
+    patterns=["*.rst", "*.py"],
+)
+
+pytest_collect_file = sybil.pytest()


### PR DESCRIPTION
Closes #8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pytest/Sybil collection to include doctest parsing and additional file patterns; main risk is unintended test collection/behavior changes in CI.
> 
> **Overview**
> Extends Sybil-based doc testing to run `DocTestParser` (with `ELLIPSIS`) in addition to `PythonCodeBlockParser`.
> 
> Broadens Sybil collection from only `*.rst` to `*.rst` and `*.py` via `patterns=["*.rst", "*.py"]`, and refactors setup to a named `sybil` instance used to create `pytest_collect_file`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fcf51b610eff88f7d6297d954c36cba252f16e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->