### PR TITLE
Update mypy exclude to match requests-mock-flask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,8 +164,9 @@ report.show_missing = true
 [tool.mypy]
 strict = true
 files = ["."]
-exclude = ["build", ".venv"]
+exclude = ["build"]
 plugins = ["mypy_strict_kwargs"]
+follow_untyped_imports = true
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"


### PR DESCRIPTION
Closes #10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects static type-checking scope (mypy may now analyze `.venv` and follow untyped dependencies), but does not change runtime behavior.
> 
> **Overview**
> Updates `pyproject.toml` mypy settings to **only exclude `build/`** (no longer excluding `.venv`) and enables `follow_untyped_imports`, aligning mypy behavior with the referenced project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e49fe776426c3c20f259ac38ee4c4a9956508cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->