### PR TITLE
Simplify CI checkout (remove fetch-depth, fetch-tags)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          fetch-tags: true
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Closes #14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak; only affects how the repo is checked out in CI and could impact jobs that rely on git history or tags (none are apparent in this workflow).
> 
> **Overview**
> Simplifies the CI `actions/checkout` step by removing `fetch-depth: 0` and `fetch-tags: true`, so CI now uses the default shallow checkout without explicitly fetching tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9e8c016d154def3fd1f97ea64dd0d59e3aa61a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->