### PR TITLE
Remove LICENSE from check-manifest ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ ignore = [
     "CHANGELOG.rst",
     "CODE_OF_CONDUCT.rst",
     "CONTRIBUTING.rst",
-    "LICENSE",
     "Makefile",
     "ci",
     "ci/**",


### PR DESCRIPTION
Addresses https://github.com/adamtheturtle/wiremock-mock/pull/28#discussion_r2870022023

`LICENSE` has legal distribution requirements, so it's valuable to keep `check-manifest` checking for its presence in the sdist. Removing it from the ignore list restores that safety check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `check-manifest` configuration to ensure `LICENSE` is validated in sdists, with no runtime or API impact.
> 
> **Overview**
> Removes `LICENSE` from the `tool.check-manifest.ignore` list in `pyproject.toml`, so `check-manifest` will fail if the license file is missing from the source distribution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6dfb4b5a1668c8c35b19a04cdd910aa1f51199c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->