### PR TITLE
Remove bdist_wheel.universal to fix incorrect Python 2 wheel tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ zip-safe = false
 package-data.wiremock_mock = ["py.typed"]
 packages.find.where = ["src"]
 
-[tool.distutils]
-bdist_wheel.universal = true
-
 [tool.setuptools_scm]
 # This keeps the start of the version the same as the last release.
 # This is useful for our documentation to include e.g. binary links


### PR DESCRIPTION
## Summary

- Removes `[tool.distutils]` section with `bdist_wheel.universal = true` from `pyproject.toml`
- This setting was producing `py2.py3-none-any` wheel tags, falsely advertising Python 2 compatibility
- This package requires Python `>=3.12` and declares `Programming Language :: Python :: 3 :: Only`, so wheels should be tagged `py3-none-any`

Addresses the issue flagged in [#26](https://github.com/adamtheturtle/wiremock-mock/pull/26#discussion_r2870020726).

## Test plan

- [ ] Build a wheel and verify it is tagged `py3-none-any` (not `py2.py3-none-any`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging-metadata-only change that affects wheel tags during release builds, with no runtime code impact.
> 
> **Overview**
> Removes the `[tool.distutils]` configuration in `pyproject.toml` that set `bdist_wheel.universal = true`.
> 
> This stops builds from producing `py2.py3-none-any` wheel tags and aligns published artifacts with the project’s Python 3-only support (>=3.12).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a90e9882f7773d55befca1ab8f89bc0c24c8a3b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->