### PR TITLE
Align Ruff config with requests-mock-flask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,6 @@ lint.ignore = [
     "ISC001",
 ]
 lint.per-file-ignores."tests/test_*.py" = [
-    # Do not require tests to have a one-line summary.
-    "D205",
     # Allow 'assert' as we use it for tests.
     "S101",
 ]


### PR DESCRIPTION
Closes #5

Updates the Ruff configuration to match `requests-mock-flask`:
- `line-length = 79`
- `lint.select = ["ALL"]` (replaces `lint.extend-select`)
- `lint.ignore = ["COM812", "D205", "D212", "ISC001"]`
- `lint.per-file-ignores."tests/test_*.py" = ["D205", "S101"]`
- `lint.unfixable = ["ERA001"]`
- `lint.mccabe.max-complexity = 12`
- `lint.pydocstyle.convention = "google"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint/format configuration-only changes; main risk is new/changed Ruff rules causing CI failures or requiring follow-up code formatting tweaks.
> 
> **Overview**
> Updates `pyproject.toml` Ruff settings to align with `requests-mock-flask`: switches to `lint.select = ["ALL"]`, tightens `line-length` to 79, and adds explicit `lint.ignore` entries for formatter/docstring-related rules.
> 
> Adds targeted per-file ignores for test files (allowing `assert`) and sets `lint.pydocstyle.convention = "google"`, while keeping `ERA001` commented-out-code removal as unfixable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52bba15ec72e5ed1a05b365bf829246102d366f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->