### PR TITLE
Expand vulture ignore_names to align with requests-mock-flask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,12 +220,46 @@ ignore_path = [
 ]
 
 [tool.vulture]
+# Ideally we would limit the paths to the source code where we want to ignore names,
+# but Vulture does not enable this.
 ignore_names = [
     "add_wiremock_to_respx",
     "load_stubs",
     "base_url",
     "request",
+    # pytest configuration
+    "pytest_collect_file",
+    "pytest_collection_modifyitems",
+    "pytest_plugins",
+    # pytest fixtures - we name fixtures like this for this purpose
+    "fixture_*",
+    # Sphinx
+    "autoclass_content",
+    "autodoc_member_order",
+    "copybutton_exclude",
+    "extensions",
+    "html_show_copyright",
+    "html_show_sourcelink",
+    "html_show_sphinx",
+    "html_theme",
+    "html_theme_options",
+    "html_title",
+    "htmlhelp_basename",
+    "intersphinx_mapping",
+    "language",
+    "linkcheck_ignore",
+    "linkcheck_retries",
+    "master_doc",
+    "nitpicky",
+    "project_copyright",
+    "pygments_style",
+    "rst_prolog",
+    "source_suffix",
+    "spelling_word_list_filename",
+    "templates_path",
+    "warning_is_error",
 ]
+# Duplicate some of .gitignore
 exclude = [".venv"]
 
 [tool.yamlfix]


### PR DESCRIPTION
Closes #15

Adds pytest/Sphinx-related `ignore_names` to the vulture config, aligning with `requests-mock-flask`:
- pytest configuration names (`pytest_collect_file`, `pytest_collection_modifyitems`, `pytest_plugins`)
- pytest fixture pattern (`fixture_*`)
- Sphinx configuration names (`autoclass_content`, `extensions`, `html_theme`, etc.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates static-analysis configuration (`vulture`) to reduce false positives; no runtime code paths are changed.
> 
> **Overview**
> Expands `pyproject.toml`’s `vulture` configuration by adding pytest and Sphinx-related entries to `ignore_names` (including fixture patterns like `fixture_*` and pytest hook names such as `pytest_collect_file`).
> 
> Also adds small clarifying comments and keeps `.venv` excluded, aligning dead-code detection with the project’s test/docs configuration so these symbols aren’t flagged as unused.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31a62de2a7cc68c5b34b2794202357ab6a06b5a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->