### PR TITLE
Expand pylint config to align with requests-mock-flask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ lint.mccabe.max-complexity = 12
     "too-many-arguments",
     "too-many-instance-attributes",
     "too-many-return-statements",
+    "too-many-branches",
     "too-many-lines",
     "locally-disabled",
     # Let ruff handle long lines
@@ -181,6 +182,8 @@ lint.mccabe.max-complexity = 12
     "duplicate-code",
     # Let ruff handle imports
     "wrong-import-order",
+    # Python 3.15+ sets a default encoding; not relevant for our supported versions
+    "unspecified-encoding",
 ]
 # We ignore invalid names because:
 # - We want to use generated module names, which may not be valid, but are never seen.


### PR DESCRIPTION
Closes #16

Expands the pylint configuration to match `requests-mock-flask`:
- `"FORMAT".single-line-if-stmt = false`
- `"MASTER".persistent = true`
- Full `"MASTER".load-plugins` list with pylint extensions
- `"DESIGN".max-complexity = 12`
- Full `"MESSAGES CONTROL".enable` list
- Expanded `"MESSAGES CONTROL".disable` list
- Cleaned up `"MESSAGES CONTROL".per-file-ignores` (removed `missing-module-docstring` entries)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to static analysis configuration (Pylint settings/plugins and message enable/disable lists) and do not affect runtime behavior.
> 
> **Overview**
> Aligns `pyproject.toml`’s Pylint configuration with a stricter baseline by adding persistence, explicitly disabling single-line `if` statements, and loading a broader set of `pylint.extensions` plugins.
> 
> Expands `MESSAGES CONTROL` to explicitly enable additional pragma/suppression checks and refines the disabled checks list (delegating more formatting/import concerns to Ruff). Per-file ignores are simplified by dropping `missing-module-docstring` ignores for generated docs modules, keeping `invalid-name` only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0472fe1f7d7fe54b8bf4b1c99e49591afe4ab378. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->