### PR TITLE
Add .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ ci:
     - mypy
     - mypy-docs
     - pylint
+    - pylint-docs
     - pyproject-fmt-fix
     - pyright
     - pyright-docs
@@ -249,7 +250,6 @@ repos:
           --command="vulture"
         language: python
         types_or: [markdown, rst]
-        pass_filenames: false
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
 


### PR DESCRIPTION
Closes #3

Adds `.pre-commit-config.yaml` based on `requests-mock-flask`, so `prek` can run hooks. Includes:
- `meta`, `pre-commit-hooks`, and `pygrep-hooks` repos
- Local hooks for all linters: actionlint, pydocstringformatter, shellcheck, shfmt, mypy, check-manifest, pyright, pyright-verifytypes, ty, pyrefly, vulture, pyroma, deptry, pylint, ruff, doc8, interrogate, pyproject-fmt, sphinx, yamlfix, zizmor, sphinx-lint
- Adapted `pyright-verifytypes` to use `wiremock_mock` module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds developer tooling configuration only, with no runtime code changes; main impact is potential friction if hooks are slow or misconfigured.
> 
> **Overview**
> Introduces a new `.pre-commit-config.yaml` that enables `pre-commit`/`pre-push` hooks for common repo hygiene checks plus a broad set of Python/docs/shell linters and formatters executed via `uv run --extra=dev`.
> 
> Configures which hooks run at *pre-commit* vs *pre-push* vs *manual*, and adds a `ci.skip` list to avoid running the toolchain in pre-commit CI (given reliance on system Python deps), including a `pyright --verifytypes wiremock_mock` check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bda51d79ff52407d36be93e0b328a45d81e2d98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->