### PR TITLE
Add README badges and contents table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,14 @@
+|Build Status| |PyPI|
+
 wiremock-mock
 =============
 
 Serve WireMock stubs as a mock with `respx`_.
 
-.. _respx: https://lundberg.github.io/respx/
+Requires Python |minimum-python-version|\+.
+
+.. contents::
+   :local:
 
 Installation
 ------------
@@ -28,9 +33,16 @@ Usage
    import httpx
    import respx
 
-   from wiremock_mock import add_wiremock_to_respx, load_stubs
+   from wiremock_mock import add_wiremock_to_respx
 
-   stubs = load_stubs("tests/fixtures/minimal-stubs.json")
+   stubs = {
+       "mappings": [
+           {
+               "request": {"method": "GET", "urlPath": "/v1/pages"},
+               "response": {"status": 200, "jsonBody": {"object": "list", "results": []}},
+           },
+       ],
+   }
    with respx.mock(base_url="http://notion-mock.test", assert_all_called=False) as m:
        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url="http://notion-mock.test")
        response = httpx.get("http://notion-mock.test/v1/pages")
@@ -38,11 +50,20 @@ Usage
 
 This lets you use existing WireMock stub files (e.g. from the WireMock Admin API
 import format) without running WireMock in Docker. All HTTP traffic is mocked at
-the ``httpx`` level via respx.
+the ``httpx`` level via respx. To load stubs from a JSON file, use
+``json.loads(path.read_text())``.
 
 Supported stub features
-----------------------
+-----------------------
 
 - **Request matching**: ``method``, ``urlPath`` (exact), ``urlPathPattern`` (regex)
 - **Query parameters**: ``queryParameters`` with ``equalTo``
 - **Response**: ``status``, ``headers``, ``jsonBody``, ``body``
+
+.. _respx: https://lundberg.github.io/respx/
+
+.. |Build Status| image:: https://github.com/adamtheturtle/wiremock-mock/actions/workflows/ci.yml/badge.svg?branch=main
+   :target: https://github.com/adamtheturtle/wiremock-mock/actions
+.. |PyPI| image:: https://badge.fury.io/py/wiremock-mock.svg
+   :target: https://badge.fury.io/py/wiremock-mock
+.. |minimum-python-version| replace:: 3.12


### PR DESCRIPTION
Closes #13

Adds to `README.rst`:
- Build Status badge (GitHub Actions CI workflow)
- PyPI badge
- `.. contents:: :local:` for a table of contents
- `|minimum-python-version| replace:: 3.12` substitution used in "Requires Python X+"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `README.rst` with no runtime or dependency impact; low risk aside from potential formatting/link correctness.
> 
> **Overview**
> Adds GitHub Actions Build Status and PyPI badges to `README.rst`, plus a local table of contents.
> 
> Updates the README usage example to inline a stub mapping (and removes the `load_stubs` reference), and documents loading JSON stubs via `json.loads(path.read_text())`. Also clarifies the minimum supported Python version via a `|minimum-python-version|` substitution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20edb4e10a07f516fe9ddb505abc9d49e5e25c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->