### PR TITLE
Add dependabot config for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` matching the configuration from `requests-mock-flask`
- Enables daily dependency updates for pip packages and GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only a Dependabot configuration file and does not change runtime code paths. The main impact is increased PR volume from daily dependency update checks.
> 
> **Overview**
> Adds `.github/dependabot.yml` to enable **daily Dependabot update PRs** for `pip` dependencies and `github-actions` workflows, with a `pip` PR cap of 10 open PRs at a time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7291f0f257865639272a50ee77681db9baec226. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->