### PR TITLE
Use match to classify WireMock stub JSON shapes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,11 +324,11 @@ ignore_names = [
     "base_url",
     "request",
     # Internal TypedDict classes used via cast() string literals
-    "_Mapping",
     "_QueryParamMatcher",
     "_RequestSpec",
     "_ResponseSpec",
     # TypedDict fields accessed via string keys (not attribute access)
+    "body",
     "equalTo",
     "jsonBody",
     "queryParameters",

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -30,7 +30,7 @@ def _build_path_pattern(
         lookaheads: list[str] = []
         for param_name, param_matcher in query_params.items():
             match param_matcher:
-                case {"equalTo": eq_val}:
+                case {"equalTo": eq_val} if eq_val is not None:
                     value = re.escape(pattern=str(object=eq_val))
                     lookaheads.append(
                         f"(?=.*{re.escape(pattern=param_name)}={value})"
@@ -79,10 +79,16 @@ def _build_response(
                 headers=headers,
                 content=s.encode(),
             )
-        case _:
+        case None:
             return httpx.Response(
                 status_code=status,
                 headers=headers,
+            )
+        case other:
+            return httpx.Response(
+                status_code=status,
+                headers=headers,
+                content=str(object=other).encode(),
             )
 
 
@@ -132,6 +138,7 @@ def add_wiremock_to_respx(
         url_path = request_raw.get("urlPath")
         url_path_pattern = request_raw.get("urlPathPattern")
 
+        query_params: dict[str, Any] | None
         match request_raw.get("queryParameters"):
             case dict() as query_params:
                 pass

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -1,21 +1,11 @@
 """Package for serving WireMock stubs as a mock with respx."""
 
 import re
-from typing import Any, TypeGuard
+from typing import Any
 
 import httpx
 import respx
 from beartype import beartype
-
-
-def _is_dict(value: object, /) -> TypeGuard[dict[str, Any]]:
-    """Check if a value is a dict, narrowing to ``dict[str, Any]``."""
-    return isinstance(value, dict)
-
-
-def _is_list(value: object, /) -> TypeGuard[list[Any]]:
-    """Check if a value is a list, narrowing to ``list[Any]``."""
-    return isinstance(value, list)
 
 
 def _build_path_pattern(
@@ -39,19 +29,61 @@ def _build_path_pattern(
     if query_params:
         lookaheads: list[str] = []
         for param_name, param_matcher in query_params.items():
-            if not _is_dict(param_matcher):
-                continue
-            eq_val = param_matcher.get("equalTo")
-            if eq_val is not None:
-                value = re.escape(pattern=str(object=eq_val))
-                lookaheads.append(
-                    f"(?=.*{re.escape(pattern=param_name)}={value})"
-                )
+            match param_matcher:
+                case {"equalTo": eq_val}:
+                    value = re.escape(pattern=str(object=eq_val))
+                    lookaheads.append(
+                        f"(?=.*{re.escape(pattern=param_name)}={value})"
+                    )
         if lookaheads:
             full_pattern += r"\?" + "".join(lookaheads) + r".*"
 
     full_pattern += r"(\?.*)?$"
     return re.compile(pattern=full_pattern)
+
+
+def _build_response(
+    *,
+    response_raw: dict[str, Any],
+) -> httpx.Response:
+    """Build an httpx Response from a WireMock response dict."""
+    match response_raw.get("status"):
+        case int() as status:
+            pass
+        case _:
+            status = 200
+
+    headers_raw = response_raw.get("headers")
+    headers: dict[str, str] = (
+        headers_raw if isinstance(headers_raw, dict) else {}
+    )
+
+    json_body = response_raw.get("jsonBody")
+    if json_body is not None:
+        return httpx.Response(
+            status_code=status,
+            headers=headers,
+            json=json_body,
+        )
+
+    match response_raw.get("body"):
+        case bytes() as b:
+            return httpx.Response(
+                status_code=status,
+                headers=headers,
+                content=b,
+            )
+        case str() as s:
+            return httpx.Response(
+                status_code=status,
+                headers=headers,
+                content=s.encode(),
+            )
+        case _:
+            return httpx.Response(
+                status_code=status,
+                headers=headers,
+            )
 
 
 @beartype
@@ -76,18 +108,22 @@ def add_wiremock_to_respx(
         ``json.loads(path.read_text())``).
     :param base_url: Base URL for all routes. Must match ``respx.mock()``.
     """
-    raw: object = stubs.get("mappings") or []
-    if not _is_list(raw):
-        return
+    match stubs.get("mappings") or []:
+        case list() as raw:
+            pass
+        case _:
+            return
 
     for item in raw:
-        if not _is_dict(item):
-            continue
+        match item:
+            case {
+                "request": dict() as request_raw,
+                "response": dict() as response_raw,
+            }:
+                pass
+            case _:
+                continue
 
-        request_raw = item.get("request")
-        response_raw = item.get("response")
-        if not _is_dict(request_raw) or not _is_dict(response_raw):
-            continue
         method_raw: object = request_raw.get("method") or "GET"
         if not isinstance(method_raw, str):
             continue
@@ -95,10 +131,12 @@ def add_wiremock_to_respx(
 
         url_path = request_raw.get("urlPath")
         url_path_pattern = request_raw.get("urlPathPattern")
-        query_params_raw = request_raw.get("queryParameters")
-        query_params: dict[str, Any] | None = (
-            query_params_raw if _is_dict(query_params_raw) else None
-        )
+
+        match request_raw.get("queryParameters"):
+            case dict() as query_params:
+                pass
+            case _:
+                query_params = None
 
         if url_path is None and url_path_pattern is None:
             continue
@@ -110,36 +148,7 @@ def add_wiremock_to_respx(
             else None
         )
 
-        status_raw = response_raw.get("status")
-        status = status_raw if isinstance(status_raw, int) else 200
-
-        headers_raw = response_raw.get("headers")
-        headers: dict[str, str] = headers_raw if _is_dict(headers_raw) else {}
-
-        json_body = response_raw.get("jsonBody")
-        body = response_raw.get("body")
-
-        if json_body is not None:
-            response = httpx.Response(
-                status_code=status,
-                headers=headers,
-                json=json_body,
-            )
-        elif body is not None:
-            response = httpx.Response(
-                status_code=status,
-                headers=headers,
-                content=(
-                    body
-                    if isinstance(body, bytes)
-                    else str(object=body).encode()
-                ),
-            )
-        else:
-            response = httpx.Response(
-                status_code=status,
-                headers=headers,
-            )
+        response = _build_response(response_raw=response_raw)
 
         url_pattern = _build_path_pattern(
             base_url=base_url,

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -1,11 +1,35 @@
 """Package for serving WireMock stubs as a mock with respx."""
 
 import re
-from typing import Any
+from typing import Any, TypedDict, cast
 
 import httpx
 import respx
 from beartype import beartype
+
+
+class _QueryParamMatcher(TypedDict, total=False):
+    """A WireMock query parameter matcher."""
+
+    equalTo: object
+
+
+class _RequestSpec(TypedDict, total=False):
+    """A WireMock request specification."""
+
+    method: object
+    urlPath: object
+    urlPathPattern: object
+    queryParameters: object
+
+
+class _ResponseSpec(TypedDict, total=False):
+    """A WireMock response specification."""
+
+    status: object
+    headers: object
+    jsonBody: object
+    body: object
 
 
 def _build_path_pattern(
@@ -13,7 +37,7 @@ def _build_path_pattern(
     base_url: str,
     path: str,
     path_pattern: str | None,
-    query_params: dict[str, Any] | None,
+    query_params: dict[str, object] | None,
 ) -> re.Pattern[str]:
     """Build a URL pattern for matching requests."""
     base = base_url.rstrip("/")
@@ -29,12 +53,17 @@ def _build_path_pattern(
     if query_params:
         lookaheads: list[str] = []
         for param_name, param_matcher in query_params.items():
-            match param_matcher:
+            if not isinstance(param_matcher, dict):
+                continue
+            eq_matcher = cast("_QueryParamMatcher", param_matcher)
+            match eq_matcher:
                 case {"equalTo": eq_val} if eq_val is not None:
                     value = re.escape(pattern=str(object=eq_val))
                     lookaheads.append(
                         f"(?=.*{re.escape(pattern=param_name)}={value})"
                     )
+                case _:
+                    pass
         if lookaheads:
             full_pattern += r"\?" + "".join(lookaheads) + r".*"
 
@@ -44,21 +73,23 @@ def _build_path_pattern(
 
 def _build_response(
     *,
-    response_raw: dict[str, Any],
+    response_spec: _ResponseSpec,
 ) -> httpx.Response:
     """Build an httpx Response from a WireMock response dict."""
-    match response_raw.get("status"):
+    match response_spec.get("status"):
         case int() as status:
             pass
         case _:
             status = 200
 
-    headers_raw = response_raw.get("headers")
+    headers_raw = response_spec.get("headers")
     headers: dict[str, str] = (
-        headers_raw if isinstance(headers_raw, dict) else {}
+        cast("dict[str, str]", headers_raw)
+        if isinstance(headers_raw, dict)
+        else {}
     )
 
-    json_body = response_raw.get("jsonBody")
+    json_body = response_spec.get("jsonBody")
     if json_body is not None:
         return httpx.Response(
             status_code=status,
@@ -66,7 +97,7 @@ def _build_response(
             json=json_body,
         )
 
-    match response_raw.get("body"):
+    match response_spec.get("body"):
         case bytes() as b:
             return httpx.Response(
                 status_code=status,
@@ -114,34 +145,37 @@ def add_wiremock_to_respx(
         ``json.loads(path.read_text())``).
     :param base_url: Base URL for all routes. Must match ``respx.mock()``.
     """
-    match stubs.get("mappings") or []:
-        case list() as raw:
-            pass
-        case _:
-            return
+    raw: object = stubs.get("mappings") or []
+    if not isinstance(raw, list):
+        return
+    mappings = cast("list[object]", raw)
 
-    for item in raw:
-        match item:
+    for item in mappings:
+        if not isinstance(item, dict):
+            continue
+        mapping = cast("dict[str, object]", item)
+        match mapping:
             case {
-                "request": dict() as request_raw,
-                "response": dict() as response_raw,
+                "request": dict(),
+                "response": dict(),
             }:
-                pass
+                request_spec = cast("_RequestSpec", mapping["request"])
+                response_spec = cast("_ResponseSpec", mapping["response"])
             case _:
                 continue
 
-        method_raw: object = request_raw.get("method") or "GET"
+        method_raw: object = request_spec.get("method") or "GET"
         if not isinstance(method_raw, str):
             continue
         method = method_raw.upper()
 
-        url_path = request_raw.get("urlPath")
-        url_path_pattern = request_raw.get("urlPathPattern")
-
-        query_params: dict[str, Any] | None
-        match request_raw.get("queryParameters"):
-            case dict() as query_params:
-                pass
+        url_path = request_spec.get("urlPath")
+        url_path_pattern = request_spec.get("urlPathPattern")
+        query_params_raw = request_spec.get("queryParameters")
+        query_params: dict[str, object] | None
+        match query_params_raw:
+            case dict():
+                query_params = cast("dict[str, object]", query_params_raw)
             case _:
                 query_params = None
 
@@ -155,7 +189,7 @@ def add_wiremock_to_respx(
             else None
         )
 
-        response = _build_response(response_raw=response_raw)
+        response = _build_response(response_spec=response_spec)
 
         url_pattern = _build_path_pattern(
             base_url=base_url,

--- a/tests/test_add_wiremock_to_respx.py
+++ b/tests/test_add_wiremock_to_respx.py
@@ -199,6 +199,23 @@ def test_add_wiremock_to_respx_body_response() -> None:
         assert response.text == "plain text"
 
 
+def test_add_wiremock_to_respx_body_bytes_response() -> None:
+    """Add_wiremock_to_respx supports bytes body response."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {"method": "GET", "urlPath": "/v1/bin"},
+                "response": {"status": 200, "body": b"binary data"},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.get(url=f"{BASE_URL}/v1/bin")
+        assert response.status_code == HTTPStatus.OK
+        assert response.content == b"binary data"
+
+
 def test_add_wiremock_to_respx_path_without_leading_slash() -> None:
     """Add_wiremock_to_respx adds leading slash when urlPath lacks it."""
     stubs: dict[str, Any] = {

--- a/tests/test_add_wiremock_to_respx.py
+++ b/tests/test_add_wiremock_to_respx.py
@@ -216,6 +216,23 @@ def test_add_wiremock_to_respx_body_bytes_response() -> None:
         assert response.content == b"binary data"
 
 
+def test_add_wiremock_to_respx_body_non_string_response() -> None:
+    """Add_wiremock_to_respx converts non-str/bytes body via str()."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {"method": "GET", "urlPath": "/v1/num"},
+                "response": {"status": 200, "body": 42},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.get(url=f"{BASE_URL}/v1/num")
+        assert response.status_code == HTTPStatus.OK
+        assert response.text == "42"
+
+
 def test_add_wiremock_to_respx_path_without_leading_slash() -> None:
     """Add_wiremock_to_respx adds leading slash when urlPath lacks it."""
     stubs: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- Replace `isinstance`/`TypeGuard` checks with structural pattern matching for mapping iteration, query parameters, HTTP status default, and response body encoding
- Extract response-building logic into `_build_response` helper to stay within ruff's branch limit
- Remove now-unused `_is_dict` and `_is_list` TypeGuard helpers

Closes #133

## Test plan
- [x] All 16 existing tests pass
- [x] Ruff and all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the core stub-parsing/matching path in `add_wiremock_to_respx` and changes response construction behavior (notably `body` handling), which could subtly alter which stubs match or how responses are encoded.
> 
> **Overview**
> **Refactors WireMock stub parsing to rely on structural pattern matching.** `add_wiremock_to_respx` now uses `match/case` plus `TypedDict` casts to validate mapping/request/response shapes and query-parameter `equalTo` matchers, replacing the previous `TypeGuard` helpers.
> 
> **Extracts and expands response-building logic.** Response construction is moved into `_build_response`, which adds explicit handling for `body` as `bytes`, `str`, `None`, or other types (stringified), and tests are extended to cover bytes and non-string `body` values.
> 
> Also updates `pyproject.toml` vulture ignores for the new `TypedDict` field names (e.g., `body`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182dbcf0ef0b8ad5223cc17abcdbed2b9b840cb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->