### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,18 +2,8 @@
 
 from doctest import ELLIPSIS
 
-import pytest
-from beartype import beartype
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser, PythonCodeBlockParser
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
-
 
 sybil = Sybil(
     parsers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -73,11 +74,13 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://adamtheturtle.github.io/wiremock-mock/"
 urls.Source = "https://github.com/adamtheturtle/wiremock-mock"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -372,6 +375,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -94,6 +94,9 @@ packages.find.where = [ "src" ]
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
+    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://adamtheturtle.github.io/wiremock-mock/"
@@ -336,7 +337,6 @@ ignore_names = [
     "urlPathPattern",
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",
@@ -372,3 +372,6 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/uv.lock
+++ b/uv.lock
@@ -1282,6 +1282,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-beartype-tests"
+version = "2026.4.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/85/2a4abab012ea412757aee0c77a63759c9df997456ae75dc0a590071bf11d/pytest_beartype_tests-2026.4.19.1.tar.gz", hash = "sha256:02662a7c189666eac26d5994d8d750106c73b0cd31ed0d01222db59ba1cb6e5a", size = 85947, upload-time = "2026-04-19T07:56:18.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/c0/8c57af81595948ddab76b78635931ed5adac38fc46565e8419dc3a5046b3/pytest_beartype_tests-2026.4.19.1-py3-none-any.whl", hash = "sha256:20618dd92dc2c8e1cab94f5984a382c95d03376ef94558e54665908e56ad8cc4", size = 5198, upload-time = "2026-04-19T07:56:16.711Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2012,6 +2025,7 @@ dev = [
     { name = "pyright" },
     { name = "pyroma" },
     { name = "pytest" },
+    { name = "pytest-beartype-tests" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "shellcheck-py" },
@@ -2056,6 +2070,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest-beartype-tests", marker = "extra == 'dev'", specifier = "==2026.4.19.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.11" },
@@ -2075,6 +2090,9 @@ requires-dist = [
     { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.24.1" },
 ]
 provides-extras = ["dev", "release"]
+
+[package.metadata.requires-dev]
+dev = []
 
 [[package]]
 name = "yamlfix"

--- a/uv.lock
+++ b/uv.lock
@@ -1283,15 +1283,11 @@ wheels = [
 
 [[package]]
 name = "pytest-beartype-tests"
-version = "2026.4.19.1"
-source = { registry = "https://pypi.org/simple" }
+version = "2026.4.19.1.post5+gbc81d99a1"
+source = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git?rev=bc81d99#bc81d99a1041e4d24bd67a2eec077b6d6616e712" }
 dependencies = [
     { name = "beartype" },
     { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/85/2a4abab012ea412757aee0c77a63759c9df997456ae75dc0a590071bf11d/pytest_beartype_tests-2026.4.19.1.tar.gz", hash = "sha256:02662a7c189666eac26d5994d8d750106c73b0cd31ed0d01222db59ba1cb6e5a", size = 85947, upload-time = "2026-04-19T07:56:18.409Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/c0/8c57af81595948ddab76b78635931ed5adac38fc46565e8419dc3a5046b3/pytest_beartype_tests-2026.4.19.1-py3-none-any.whl", hash = "sha256:20618dd92dc2c8e1cab94f5984a382c95d03376ef94558e54665908e56ad8cc4", size = 5198, upload-time = "2026-04-19T07:56:16.711Z" },
 ]
 
 [[package]]
@@ -2070,7 +2066,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
-    { name = "pytest-beartype-tests", marker = "extra == 'dev'", specifier = "==2026.4.19.1" },
+    { name = "pytest-beartype-tests", marker = "extra == 'dev'", git = "https://github.com/adamtheturtle/pytest-beartype-tests.git?rev=bc81d99" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.11" },


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only wiring changes plus a new dev dependency; main risk is subtle differences in when/how `@beartype` is applied during test collection.
> 
> **Overview**
> Moves `@beartype`-wrapping of collected pytest functions from a local `pytest_collection_modifyitems` hook to the external `pytest-beartype-tests` plugin, simplifying `conftest.py` to only handle Sybil doctest collection.
> 
> Adds `pytest-beartype-tests` as a dev dependency and pins it via `uv` to a specific git revision (with corresponding `uv.lock` updates), and removes the now-unused vulture ignore for `pytest_collection_modifyitems`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cca57acdf63cae2528931a71ae4b47465bc444a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->