### PR TITLE
docs: tidy README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@ Serve WireMock stubs as a mock with `respx`_.
 
 Requires Python |minimum-python-version|\+.
 
-.. contents::
-   :local:
-
 Installation
 ------------
 
@@ -58,10 +55,8 @@ Usage
        response = httpx.get(url="http://notion-mock.test/v1/pages")
        assert response.status_code == HTTPStatus.OK  # noqa: S101
 
-This lets you use existing WireMock stub files (e.g. from the WireMock Admin API
-import format) without running WireMock in Docker. All HTTP traffic is mocked at
-the ``httpx`` level via respx. To load stubs from a JSON file, use
-``json.loads(path.read_text())``.
+All HTTP traffic is mocked at the ``httpx`` level via respx. To load stubs from
+a JSON file, use ``json.loads(path.read_text())``.
 
 Use cases
 ---------

--- a/uv.lock
+++ b/uv.lock
@@ -1240,15 +1240,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -2071,7 +2071,7 @@ requires-dist = [
     { name = "pylint-per-file-ignores", marker = "extra == 'dev'", specifier = "==3.2.1" },
     { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.21.1" },
     { name = "pyrefly", marker = "extra == 'dev'", specifier = "==0.62.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.409" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-beartype-tests", marker = "extra == 'dev'", specifier = "==2026.4.20" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change limited to README wording/formatting; no runtime behavior is affected.
> 
> **Overview**
> **README cleanup** by removing the local table-of-contents block and tightening the post-example explanation to focus on `httpx`/`respx` mocking and JSON stub loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 744ba71a5f6172c6ca67742b008c049987aa7ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->