### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
+optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 urls.Documentation = "https://adamtheturtle.github.io/wiremock-mock/"
 urls.Source = "https://github.com/adamtheturtle/wiremock-mock"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2155,6 +2155,7 @@ dev = [
 ]
 release = [
     { name = "check-wheel-contents" },
+    { name = "towncrier" },
 ]
 
 [package.metadata]
@@ -2196,6 +2197,7 @@ requires-dist = [
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.19.post3" },
     { name = "sybil", extras = ["pytest"], marker = "extra == 'dev'", specifier = "==10.0.1" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
+    { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates packaging metadata/lockfile to include an additional release-only dependency, with no runtime code changes.
> 
> **Overview**
> Ensures release environments can run `towncrier build` by adding `towncrier==25.8.0` to the `release` extra in `pyproject.toml`.
> 
> Updates `uv.lock` accordingly so `--extra=release` installs `towncrier` (and records the `extra == 'release'` requirement marker).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87bbaa5bc0131c7472e89e9f1d0030959c704bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->