### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it may cause CI/lint failures in repos that currently contain unnecessary `# pylint: disable` pragmas.
> 
> **Overview**
> Tightens Pylint linting by configuring `MAIN.fail-on = ["useless-suppression"]` in `pyproject.toml`, causing Pylint to exit non-zero when it encounters unnecessary suppression pragmas (while keeping the existing `useless-suppression` check enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59153c391b04194261b675a3b84df19db64f918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->