### PR TITLE
Support request body matching (WireMock bodyPatterns)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,10 @@ Supported stub features
 
 - **Request matching**: ``method``, ``urlPath`` (exact), ``urlPathPattern`` (regex)
 - **Query parameters**: ``queryParameters`` with ``equalTo``
+- **Request body**: ``bodyPatterns`` with ``equalToJson`` (honouring
+  ``ignoreArrayOrder`` and ``ignoreExtraElements``), ``contains`` and
+  ``equalTo``. This lets two requests to the same method and URL return
+  different responses based on their bodies.
 - **Response**: ``status``, ``headers``, ``jsonBody``, ``body``
 
 Full documentation

--- a/newsfragments/228.change.rst
+++ b/newsfragments/228.change.rst
@@ -1,0 +1,1 @@
+Added support for matching requests on their body with WireMock ``bodyPatterns``: ``equalToJson`` (honouring ``ignoreArrayOrder`` and ``ignoreExtraElements``), ``contains`` and ``equalTo``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,7 @@ ignore_names = [
     "base_url",
     # TypedDict fields accessed via string keys (not attribute access)
     "body",
+    "bodyPatterns",
     "copybutton_exclude",
     "equalTo",
     "extensions",
@@ -327,6 +328,8 @@ ignore_names = [
     "linkcheck_ignore",
     "linkcheck_retries",
     "master_doc",
+    # respx ``Pattern.match`` is invoked dynamically by respx
+    "match",
     "nitpicky",
     "project_copyright",
     "pygments_style",

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -2,8 +2,17 @@ Changelog
 JSON
 Pytest
 beartype
+honouring
 httpx
 macOS
+matcher
+matchers
+multisets
 params
+positionally
 respx
+str
+subsequence
+substring
+unhandled
 wiremock

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -409,7 +409,7 @@ def add_wiremock_to_respx(
     - ``queryParameters`` with ``equalTo``
     - ``bodyPatterns`` (``equalToJson``, ``contains``, ``equalTo``)
 
-    ``equalToJson`` honours the ``ignoreArrayOrder`` and
+    ``equalToJson`` supports the ``ignoreArrayOrder`` and
     ``ignoreExtraElements`` options. Multiple ``bodyPatterns`` on a single
     stub must all match, letting two requests to the same method and URL
     return different responses based on their bodies.

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -221,8 +221,11 @@ def _equal_to_json_predicate(
         """Return whether the request body matches ``expected`` as
         JSON.
         """
+        text = _request_text(request=request)
+        if text is None:
+            return False
         try:
-            actual = json.loads(s=request.read())
+            actual = json.loads(s=text)
         except json.JSONDecodeError:
             return False
         return _json_values_match(
@@ -404,12 +407,12 @@ def add_wiremock_to_respx(
     - method
     - ``urlPath`` (exact) or ``urlPathPattern`` (regex)
     - ``queryParameters`` with ``equalTo``
-    - ``bodyPatterns`` with ``equalToJson`` (honouring ``ignoreArrayOrder``
-      and ``ignoreExtraElements``), ``contains`` and ``equalTo``
+    - ``bodyPatterns`` (``equalToJson``, ``contains``, ``equalTo``)
 
-    Multiple ``bodyPatterns`` on a single stub must all match. This lets two
-    requests to the same method and URL return different responses based on
-    their bodies.
+    ``equalToJson`` honours the ``ignoreArrayOrder`` and
+    ``ignoreExtraElements`` options. Multiple ``bodyPatterns`` on a single
+    stub must all match, letting two requests to the same method and URL
+    return different responses based on their bodies.
 
     Response uses status, headers, and ``jsonBody`` from each stub.
 

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -1,11 +1,14 @@
 """Package for serving WireMock stubs as a mock with respx."""
 
+import json
 import re
+from collections.abc import Callable
 from typing import Any, TypedDict, cast  # noqa: TID251
 
 import httpx
 import respx
 from beartype import beartype
+from respx.patterns import Match, Pattern
 
 
 class _QueryParamMatcher(TypedDict, total=False):
@@ -21,6 +24,7 @@ class _RequestSpec(TypedDict, total=False):
     urlPath: object
     urlPathPattern: object
     queryParameters: object
+    bodyPatterns: object
 
 
 class _ResponseSpec(TypedDict, total=False):
@@ -30,6 +34,269 @@ class _ResponseSpec(TypedDict, total=False):
     headers: object
     jsonBody: object
     body: object
+
+
+def _coerce_json(*, value: object) -> object:
+    """
+    Coerce a WireMock ``equalToJson`` value to a comparable JSON value.
+
+    The value may be given either as a JSON value directly or as a string
+    containing JSON. Strings that are not valid JSON are returned unchanged.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(s=value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _json_values_match(
+    *,
+    expected: object,
+    actual: object,
+    ignore_array_order: bool,
+    ignore_extra_elements: bool,
+) -> bool:
+    """Return whether ``actual`` matches ``expected`` JSON, per the
+    flags.
+    """
+    match expected:
+        case dict():
+            return _json_objects_match(
+                expected=cast("dict[object, object]", expected),
+                actual=actual,
+                ignore_array_order=ignore_array_order,
+                ignore_extra_elements=ignore_extra_elements,
+            )
+        case list():
+            return isinstance(actual, list) and _json_arrays_match(
+                expected=cast("list[object]", expected),
+                actual=cast("list[object]", actual),
+                ignore_array_order=ignore_array_order,
+                ignore_extra_elements=ignore_extra_elements,
+            )
+        case _:
+            return expected == actual
+
+
+def _json_objects_match(
+    *,
+    expected: dict[object, object],
+    actual: object,
+    ignore_array_order: bool,
+    ignore_extra_elements: bool,
+) -> bool:
+    """Return whether ``actual`` matches the ``expected`` JSON object."""
+    if not isinstance(actual, dict):
+        return False
+    actual_obj = cast("dict[object, object]", actual)
+    if not ignore_extra_elements and expected.keys() != actual_obj.keys():
+        return False
+    for key, expected_value in expected.items():
+        if key not in actual_obj:
+            return False
+        if not _json_values_match(
+            expected=expected_value,
+            actual=actual_obj[key],
+            ignore_array_order=ignore_array_order,
+            ignore_extra_elements=ignore_extra_elements,
+        ):
+            return False
+    return True
+
+
+def _json_arrays_match(
+    *,
+    expected: list[object],
+    actual: list[object],
+    ignore_array_order: bool,
+    ignore_extra_elements: bool,
+) -> bool:
+    """Return whether ``actual`` matches the ``expected`` JSON array."""
+    if ignore_array_order:
+        return _json_arrays_match_unordered(
+            expected=expected,
+            actual=actual,
+            ignore_extra_elements=ignore_extra_elements,
+        )
+    return _json_arrays_match_ordered(
+        expected=expected,
+        actual=actual,
+        ignore_extra_elements=ignore_extra_elements,
+    )
+
+
+def _json_arrays_match_unordered(
+    *,
+    expected: list[object],
+    actual: list[object],
+    ignore_extra_elements: bool,
+) -> bool:
+    """Match arrays as multisets, ignoring element order."""
+    used = [False] * len(actual)
+    for expected_item in expected:
+        for index, actual_item in enumerate(iterable=actual):
+            if not used[index] and _json_values_match(
+                expected=expected_item,
+                actual=actual_item,
+                ignore_array_order=True,
+                ignore_extra_elements=ignore_extra_elements,
+            ):
+                used[index] = True
+                break
+        else:
+            return False
+    return ignore_extra_elements or all(used)
+
+
+def _json_arrays_match_ordered(
+    *,
+    expected: list[object],
+    actual: list[object],
+    ignore_extra_elements: bool,
+) -> bool:
+    """Match arrays positionally, preserving element order."""
+    if not ignore_extra_elements and len(expected) != len(actual):
+        return False
+    actual_iter = iter(actual)
+    for expected_item in expected:
+        for actual_item in actual_iter:
+            if _json_values_match(
+                expected=expected_item,
+                actual=actual_item,
+                ignore_array_order=False,
+                ignore_extra_elements=ignore_extra_elements,
+            ):
+                break
+        else:
+            return False
+    return True
+
+
+def _request_text(*, request: httpx.Request) -> str | None:
+    """Return the request body as text, or ``None`` if it is not text."""
+    try:
+        return request.read().decode()
+    except UnicodeDecodeError:
+        return None
+
+
+def _equal_to_predicate(
+    *,
+    expected: str,
+) -> Callable[[httpx.Request], bool]:
+    """Build a predicate matching the raw request body exactly."""
+
+    def predicate(request: httpx.Request) -> bool:
+        """Return whether the request body equals ``expected``."""
+        return _request_text(request=request) == expected
+
+    return predicate
+
+
+def _contains_predicate(
+    *,
+    substring: str,
+) -> Callable[[httpx.Request], bool]:
+    """Build a predicate matching a substring of the raw request body."""
+
+    def predicate(request: httpx.Request) -> bool:
+        """Return whether the request body contains ``substring``."""
+        text = _request_text(request=request)
+        return text is not None and substring in text
+
+    return predicate
+
+
+def _equal_to_json_predicate(
+    *,
+    expected: object,
+    ignore_array_order: bool,
+    ignore_extra_elements: bool,
+) -> Callable[[httpx.Request], bool]:
+    """Build a predicate matching the request body as JSON."""
+
+    def predicate(request: httpx.Request) -> bool:
+        """Return whether the request body matches ``expected`` as
+        JSON.
+        """
+        try:
+            actual = json.loads(s=request.read())
+        except json.JSONDecodeError:
+            return False
+        return _json_values_match(
+            expected=expected,
+            actual=actual,
+            ignore_array_order=ignore_array_order,
+            ignore_extra_elements=ignore_extra_elements,
+        )
+
+    return predicate
+
+
+class _BodyPattern(Pattern):
+    """A WireMock request-body matcher expressed as a respx pattern."""
+
+    key = "wiremock_body"
+
+    def __init__(
+        self,
+        *,
+        identity: str,
+        predicate: Callable[[httpx.Request], bool],
+    ) -> None:
+        """
+        :param identity: A stable string identifying this matcher, used
+        so
+            that distinct body matchers produce distinct respx routes.
+        :param predicate: Returns whether a request body matches.
+        """
+        super().__init__(value=identity)
+        self._predicate = predicate
+
+    def match(self, request: httpx.Request) -> Match:
+        """Return whether ``request`` matches this body pattern."""
+        return Match(matches=self._predicate(request))
+
+
+def _build_body_pattern(*, matcher: dict[str, object]) -> _BodyPattern | None:
+    """Build a body pattern from a single WireMock body matcher."""
+    identity = json.dumps(obj=matcher, sort_keys=True, default=str)
+    ignore_array_order = matcher.get("ignoreArrayOrder") is True
+    ignore_extra_elements = matcher.get("ignoreExtraElements") is True
+
+    match matcher:
+        case {"equalToJson": equal_to_json}:
+            predicate = _equal_to_json_predicate(
+                expected=_coerce_json(value=equal_to_json),
+                ignore_array_order=ignore_array_order,
+                ignore_extra_elements=ignore_extra_elements,
+            )
+        case {"equalTo": str() as equal_to}:
+            predicate = _equal_to_predicate(expected=equal_to)
+        case {"contains": str() as contains}:
+            predicate = _contains_predicate(substring=contains)
+        case _:
+            return None
+
+    return _BodyPattern(identity=identity, predicate=predicate)
+
+
+def _build_body_patterns(*, body_patterns: object) -> list[_BodyPattern]:
+    """Build respx patterns from a WireMock ``bodyPatterns`` list."""
+    if not isinstance(body_patterns, list):
+        return []
+    patterns: list[_BodyPattern] = []
+    for matcher in cast("list[object]", body_patterns):
+        if not isinstance(matcher, dict):
+            continue
+        pattern = _build_body_pattern(
+            matcher=cast("dict[str, object]", matcher)
+        )
+        if pattern is not None:
+            patterns.append(pattern)
+    return patterns
 
 
 def _build_path_pattern(
@@ -137,6 +404,12 @@ def add_wiremock_to_respx(
     - method
     - ``urlPath`` (exact) or ``urlPathPattern`` (regex)
     - ``queryParameters`` with ``equalTo``
+    - ``bodyPatterns`` with ``equalToJson`` (honouring ``ignoreArrayOrder``
+      and ``ignoreExtraElements``), ``contains`` and ``equalTo``
+
+    Multiple ``bodyPatterns`` on a single stub must all match. This lets two
+    requests to the same method and URL return different responses based on
+    their bodies.
 
     Response uses status, headers, and ``jsonBody`` from each stub.
 
@@ -198,7 +471,11 @@ def add_wiremock_to_respx(
             query_params=query_params,
         )
 
-        route = mock_obj.route(method=method, url=url_pattern)
+        body_patterns = _build_body_patterns(
+            body_patterns=request_spec.get("bodyPatterns"),
+        )
+
+        route = mock_obj.route(*body_patterns, method=method, url=url_pattern)
         route.mock(return_value=response)
 
 

--- a/tests/test_add_wiremock_to_respx.py
+++ b/tests/test_add_wiremock_to_respx.py
@@ -476,6 +476,26 @@ def test_add_wiremock_to_respx_body_equal_to_json_not_json_body() -> None:
             httpx.post(url=f"{BASE_URL}/v1/pages", content=b"not json")
 
 
+def test_add_wiremock_to_respx_body_equal_to_json_non_utf8() -> None:
+    """A non-UTF-8 request body does not match ``equalToJson``."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"a": 1}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", content=b"\xff\xfe")
+
+
 def test_add_wiremock_to_respx_body_ignore_extra_elements() -> None:
     """``ignoreExtraElements`` matches a subset of object keys."""
     stubs: dict[str, Any] = {

--- a/tests/test_add_wiremock_to_respx.py
+++ b/tests/test_add_wiremock_to_respx.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from typing import Any
 
 import httpx
+import pytest
 import respx
 
 from wiremock_mock import add_wiremock_to_respx
@@ -341,6 +342,572 @@ def test_add_wiremock_to_respx_url_path_with_extra_query_params() -> None:
             params={"page_size": 100},
         )
         assert response.status_code == HTTPStatus.OK
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_equal_to_json() -> None:
+    """Two stubs at the same URL differ by ``equalToJson`` body."""
+    url = f"{BASE_URL}/v1/blocks/{_PAGE_ID}/children"
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "PATCH",
+                    "urlPath": f"/v1/blocks/{_PAGE_ID}/children",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {
+                                "children": [{"type": "image"}],
+                            },
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"type": "image"}},
+            },
+            {
+                "request": {
+                    "method": "PATCH",
+                    "urlPath": f"/v1/blocks/{_PAGE_ID}/children",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {
+                                "children": [{"type": "paragraph"}],
+                            },
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"type": "paragraph"}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        image_response = httpx.patch(
+            url=url,
+            json={"children": [{"type": "image"}]},
+        )
+        paragraph_response = httpx.patch(
+            url=url,
+            json={"children": [{"type": "paragraph"}]},
+        )
+        assert image_response.json() == {"type": "image"}
+        assert paragraph_response.json() == {"type": "paragraph"}
+
+
+def test_add_wiremock_to_respx_body_equal_to_json_no_match() -> None:
+    """A request whose body matches no ``equalToJson`` stub is
+    unhandled.
+    """
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"a": 1}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"a": 2})
+
+
+def test_add_wiremock_to_respx_body_equal_to_json_from_string() -> None:
+    """``equalToJson`` may be given as a JSON string."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": '{"a": 1}'}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(url=f"{BASE_URL}/v1/pages", json={"a": 1})
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_equal_to_json_invalid_string() -> None:
+    """A non-JSON ``equalToJson`` string is compared as raw text."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": "not json"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"a": 1})
+
+
+def test_add_wiremock_to_respx_body_equal_to_json_not_json_body() -> None:
+    """A non-JSON request body does not match ``equalToJson``."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"a": 1}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", content=b"not json")
+
+
+def test_add_wiremock_to_respx_body_ignore_extra_elements() -> None:
+    """``ignoreExtraElements`` matches a subset of object keys."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {"a": 1},
+                            "ignoreExtraElements": True,
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(
+            url=f"{BASE_URL}/v1/pages",
+            json={"a": 1, "b": 2},
+        )
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_extra_elements_not_ignored() -> None:
+    """Without ``ignoreExtraElements``, extra object keys do not match."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"a": 1}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"a": 1, "b": 2})
+
+
+def test_add_wiremock_to_respx_body_ignore_array_order() -> None:
+    """``ignoreArrayOrder`` matches arrays regardless of element order."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {"items": [1, 2, 3]},
+                            "ignoreArrayOrder": True,
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(
+            url=f"{BASE_URL}/v1/pages",
+            json={"items": [3, 1, 2]},
+        )
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_array_order_enforced() -> None:
+    """Without ``ignoreArrayOrder``, array element order must match."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"items": [1, 2, 3]}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"items": [3, 1, 2]})
+
+
+def test_add_wiremock_to_respx_body_array_length_mismatch() -> None:
+    """An array of a different length does not match without flags."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"items": [1, 2]}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"items": [1, 2, 3]})
+
+
+def test_add_wiremock_to_respx_body_array_ignore_extra_ordered() -> None:
+    """``ignoreExtraElements`` matches an in-order subsequence of an array."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {"items": [1, 3]},
+                            "ignoreExtraElements": True,
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(
+            url=f"{BASE_URL}/v1/pages",
+            json={"items": [1, 2, 3]},
+        )
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_array_ignore_extra_missing() -> None:
+    """An ordered subsequence match fails when an element is missing."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {"items": [1, 4]},
+                            "ignoreExtraElements": True,
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"items": [1, 2, 3]})
+
+
+def test_add_wiremock_to_respx_body_array_unordered_missing() -> None:
+    """An unordered array match fails when an expected element is
+    absent.
+    """
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {"items": [1, 9]},
+                            "ignoreArrayOrder": True,
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"items": [1, 2, 3]})
+
+
+def test_add_wiremock_to_respx_body_object_vs_array() -> None:
+    """An object expectation does not match an array body."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": {"a": 1}}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json=[1, 2])
+
+
+def test_add_wiremock_to_respx_body_array_vs_object() -> None:
+    """An array expectation does not match an object body."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalToJson": [1, 2]}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"a": 1})
+
+
+def test_add_wiremock_to_respx_body_missing_key() -> None:
+    """An expected object key absent from the body does not match."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {
+                            "equalToJson": {"a": 1, "b": 2},
+                            "ignoreExtraElements": True,
+                        },
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", json={"a": 1})
+
+
+def test_add_wiremock_to_respx_body_contains() -> None:
+    """``contains`` matches a substring of the raw request body."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"contains": "needle"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(
+            url=f"{BASE_URL}/v1/pages",
+            content=b"a needle in a haystack",
+        )
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_contains_non_utf8() -> None:
+    """``contains`` does not match a non-UTF-8 request body."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"contains": "needle"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", content=b"\xff\xfe")
+
+
+def test_add_wiremock_to_respx_body_equal_to() -> None:
+    """``equalTo`` matches the raw request body exactly."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalTo": "exact body"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(
+            url=f"{BASE_URL}/v1/pages",
+            content=b"exact body",
+        )
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_equal_to_no_match() -> None:
+    """``equalTo`` does not match a different raw request body."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"equalTo": "exact body"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", content=b"different")
+
+
+def test_add_wiremock_to_respx_body_multiple_patterns() -> None:
+    """All ``bodyPatterns`` on a stub must match together."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [
+                        {"contains": "alpha"},
+                        {"contains": "omega"},
+                    ],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        with pytest.raises(expected_exception=AssertionError):
+            httpx.post(url=f"{BASE_URL}/v1/pages", content=b"only alpha")
+        response = httpx.post(
+            url=f"{BASE_URL}/v1/pages",
+            content=b"alpha and omega",
+        )
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_patterns_not_list() -> None:
+    """A non-list ``bodyPatterns`` is ignored."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "GET",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": "not-a-list",
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.get(url=f"{BASE_URL}/v1/pages")
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_pattern_non_dict() -> None:
+    """A non-dict body matcher entry is skipped."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": ["not-a-dict", {"contains": "x"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(url=f"{BASE_URL}/v1/pages", content=b"xyz")
+        assert response.json() == {"ok": True}
+
+
+def test_add_wiremock_to_respx_body_pattern_unsupported() -> None:
+    """An unsupported body matcher is ignored, matching any body."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {
+                    "method": "POST",
+                    "urlPath": "/v1/pages",
+                    "bodyPatterns": [{"matches": ".*"}],
+                },
+                "response": {"status": 200, "jsonBody": {"ok": True}},
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.post(url=f"{BASE_URL}/v1/pages", json={"any": True})
         assert response.json() == {"ok": True}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1053,26 +1053,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.4.4"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/13/3d71b3adbf385f7dc7fb6e16d6e25421fd8398b45d8f8410a328bf22bd3f/prek-0.4.4.tar.gz", hash = "sha256:4ec5771153d158a0e4473933b7fd9b51e1b1f57f2df50aeb7560ea6812226dc5", size = 470641, upload-time = "2026-06-04T07:26:07.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/65/23866f43521d31173879aa74bb3a2df50ab7f3f74cdb4eaa31b8f446c7ca/prek-0.4.5.tar.gz", hash = "sha256:2be7bcf839de19a0144ed5a5aadf73bc5899cf6823bb1c58cf1d45ae389c201a", size = 482566, upload-time = "2026-06-15T11:36:48.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/9f/68a577888edf7f2647a652b02899508ccd84e57ce1f79c51a44edfd308d7/prek-0.4.4-py3-none-linux_armv6l.whl", hash = "sha256:23cfd96a25de1c93e3c43c746643b80489e3b2fa49ca9c0ffd6022e51535c900", size = 5550271, upload-time = "2026-06-04T07:26:17.834Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b8/5427a0023116343a8d787b446536a7fddfa5db7eec7713dd05618da2bdfe/prek-0.4.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a427b792c4436f49732b1f6ebccf221fdcc6390c148474280da9c2c6eaabc9c4", size = 5910136, upload-time = "2026-06-04T07:26:20.616Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/4f/d751e90b7e768e472e054cd41cbe502589436ca9c1a13bfe4fa9513f9cde/prek-0.4.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b998038fc92c990e03147eb5b95b0f2c394517f8857ab911aac8e092f1b9b3ab", size = 5470124, upload-time = "2026-06-04T07:26:29.23Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/fe/e73241c5777b6f9b6b95132febbd27f9be9e89912e9e93c0982680593af2/prek-0.4.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9cebca8c15da4f1d6e3a25e6ae0611425c8596e926222050f2588c390e42df8a", size = 5732725, upload-time = "2026-06-04T07:26:19.133Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/a3/329bd910e7e5d9d0eb5e571f3ba48023213744e78411afb81f5ef8356cab/prek-0.4.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c8742ac26363e74c855df6215a709d5db183204d00ac0f1a722b13aed4da3cd0", size = 5457953, upload-time = "2026-06-04T07:26:23.41Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f8/d642990513d9707398506bad45d39173d84266231f7d919899f694aefe2c/prek-0.4.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a2b7c8710546a1e894afa7ab022030cd4e21f1ee7ffb301b4360773d22f1f00f", size = 5860556, upload-time = "2026-06-04T07:26:11.692Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/17/a2e29cb278503a8c18612d8a62a15020648dc768e2e94bc4b4d4c9411e07/prek-0.4.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e02bd4d5e05c500e4d9f70f024e30d13aa361dc490724b7f476d2e35542c239f", size = 6652492, upload-time = "2026-06-04T07:26:09.962Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/10/ad3270b18135ee5d1af6f6cf4b0c8601b1cc2cb38d16e835081da820833a/prek-0.4.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f3a25041733de987a47e5a7bace47182a6f0e2ae5f960cb54c1d4630afd2591", size = 6113837, upload-time = "2026-06-04T07:26:24.873Z" },
-    { url = "https://files.pythonhosted.org/packages/59/d9/e8c201b9b41c4561673cea01c630ab604df89d13e952f87dbcb807d32588/prek-0.4.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0b04a0f36d07474f2a9fc5b1ba1197a1b326b2b211f39cd74cf0d4613545f7f4", size = 5729155, upload-time = "2026-06-04T07:26:26.194Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cd/227b0494fcbc91e8fe15c2a4db9e6dfff95314ef38db3e40e6ea96db249d/prek-0.4.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f032ccbe2d6edc345f81a6d772c18cc169d63c27b5a8292bfe416b352bdfee57", size = 5590775, upload-time = "2026-06-04T07:26:22.038Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/e0/9d750b9cf21ece884afdc15668d0f005a36588fe1b0bb5ff4a8112ab51cb/prek-0.4.4-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:bad3586fcea3e913f0edf2e8f132f97889e03976b7ee3d120fd294ad4e89a5eb", size = 5437864, upload-time = "2026-06-04T07:26:30.673Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/48/e2e5c0299590ad18a253c0ac09508b615baa1b382010c511186572f711d3/prek-0.4.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:4058638532c6dcbf0076d23b9264cbdd9f0f0e320762e237a6b9e4e4b854a766", size = 5718579, upload-time = "2026-06-04T07:26:27.786Z" },
-    { url = "https://files.pythonhosted.org/packages/54/48/7fb3d4e7f664d1ce8ae35ec553872ffddf9fab4c5081735fdaae610b1e7c/prek-0.4.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:619bab14071670249777deea0cc0b29d904c4a514cf33b20e583900a544f0399", size = 6231622, upload-time = "2026-06-04T07:26:16.309Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c0/a4ddbf38034afe67cfa97c4bd81c86429ada098e7c323218d9f9fd061566/prek-0.4.4-py3-none-win32.whl", hash = "sha256:143154b329c05b2f9fa3230e604d02d9c4297dd43f96135a8ba166772e8ecd60", size = 5240317, upload-time = "2026-06-04T07:26:08.726Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/8c/fe97b5b095187bb2f93bbe406bccf108c879e5e4c83f165809b0d16ce0fb/prek-0.4.4-py3-none-win_amd64.whl", hash = "sha256:c38c5140ae2ea55ebb02e6ca590a416664ea1af287cdd21f54daeec53a81015a", size = 5626104, upload-time = "2026-06-04T07:26:14.81Z" },
-    { url = "https://files.pythonhosted.org/packages/25/63/3586226d536796e65f8e725b531d6104e55caaa18659bdcb512661629586/prek-0.4.4-py3-none-win_arm64.whl", hash = "sha256:3efa28fb37b9ddbafb7759da8d497f0d36cf02a05816e15d6541f5669d5d2114", size = 5470399, upload-time = "2026-06-04T07:26:13.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/cb/a9eedf9a35ca6ec72f12af2b4392d7f757bb24863b7b7af4523f939cf3fa/prek-0.4.5-py3-none-linux_armv6l.whl", hash = "sha256:f7517774c72b001573520dc7111156779fd3e5b4452c11f09ff53c71a067e835", size = 5618105, upload-time = "2026-06-15T11:36:21.998Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a7/c96c06f17db7da0a57be2be4c229aa00b525bca8001c9c765663b339cbb7/prek-0.4.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aca9fa995536036a0171bcf7a4db96dc0a14f480054eda1d7d1c2e7739650993", size = 5972998, upload-time = "2026-06-15T11:36:41.12Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f1/721695355cdaa44be6f091e3a77fb9c72ed60289520f78b2f8c9a7197bdd/prek-0.4.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:66877ff21ae9d548f0f7e56fab8e65f1500a74a810e7749188c3f35a4a1b911b", size = 5525098, upload-time = "2026-06-15T11:36:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1b/a334e1bb5361b49adf52b5ac7b6532018940f9f0f253437e8f43c3c1f7f3/prek-0.4.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:50697089a86a78d16f087c1912a2f3bc2bea82319a220fac52cc8e3ec9fc0426", size = 5793732, upload-time = "2026-06-15T11:36:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8c/aff94d276e91207a87cedff7cfefdd4aca20444137cca77bf53fffebe77a/prek-0.4.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:590427a42a3c1e5064487a0dc91167ae0c8a52168e77f574758ef9b138fcfd61", size = 5521719, upload-time = "2026-06-15T11:36:39.383Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/73/cfb0c5c909442050a8357e26233f7e511ba8e0d2f4b0bdc460065d62beb6/prek-0.4.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd98b986767dafdb6b4305b563ee5a3a8f13bd3c78b98d708626815ea9f147f", size = 5922623, upload-time = "2026-06-15T11:36:18.063Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ad/ff9d26551ba80d190bd08c6341176a5d56d4e6de9c2ebf077793d4adbb78/prek-0.4.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fccd11613ae92619d1ecda0ab3359ceebeb38898909ec84a8d383733d12158cc", size = 6722071, upload-time = "2026-06-15T11:36:43.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/11d1dfd66c919953fe89ae2fdedd4f413ee923883043816d35982177bb75/prek-0.4.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14109d37b33e5529db41a3539d4f8f72d295f6eeddede3964994d898b8cec05c", size = 6176454, upload-time = "2026-06-15T11:36:33.803Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/9749f25c2e0ee5225f812457b888acef301e0ccce64bebcda2ac1d04abee/prek-0.4.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:40d262418105b2ede9836593a1927fc927cc8093c432e998640964102196996e", size = 5791133, upload-time = "2026-06-15T11:36:23.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/72/5e0344bab1eacf813a5b1b082cb4c6253930096166dad51c1cccee0a4f83/prek-0.4.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a586d14c3b852fdee1c3dcd0b9cb0915db9f9d054334b854fd9470bf68edf129", size = 5658098, upload-time = "2026-06-15T11:36:44.862Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a5/1f406e0362dd0f18ba09a562d50d7c04a70ac05d350b1ab6fba36ca3e9f0/prek-0.4.5-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a8ed0d28f3e7790e4402a9324c386509066df6e67cc587f7406f9a245b97b7e8", size = 5498634, upload-time = "2026-06-15T11:36:31.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/df/b0cbf0fa527330188390b7b6c8d279cd5e509923262d0a6c5cc44bbdf103/prek-0.4.5-py3-none-musllinux_1_1_i686.whl", hash = "sha256:86f76bd3d2ecf6fd9034d75c62ff4c786eb11d0dd0a1f79bbb4343b023e12769", size = 5784840, upload-time = "2026-06-15T11:36:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d7/977ee3c622c906677dd94187a00392ce2dd76035486b3a3b1b5a5267dd34/prek-0.4.5-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e491a1a4641d91d8b03dcce5588397e76d2a5b432c9b0a6c70475972b4512ab4", size = 6300384, upload-time = "2026-06-15T11:36:27.602Z" },
+    { url = "https://files.pythonhosted.org/packages/79/fa/43b1d761381dc1c7eeb8f2235c66e902970d4b2bff2dec0f02836c085769/prek-0.4.5-py3-none-win32.whl", hash = "sha256:7546989b2403c96137bd79d19ebfe21facb87266cefe819db2458c3b9b23f350", size = 5287935, upload-time = "2026-06-15T11:36:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/fe/59b5eb3124f5a4cc255a93857b9ab42402635b273f157e91de23bfa40e8f/prek-0.4.5-py3-none-win_amd64.whl", hash = "sha256:8b2ac9227504371d97338215b344184cb0b31ca94113515a3a90c509c6c5a707", size = 5682560, upload-time = "2026-06-15T11:36:25.865Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0e/589ff0eab9034909b1ec8654ee03483797305fb743b3554ce6140d82da9d/prek-0.4.5-py3-none-win_arm64.whl", hash = "sha256:646a86a1a082dbd99fed96314b1064f5644bb34c1f4037a63547a18e2160fb86", size = 5509019, upload-time = "2026-06-15T11:36:46.595Z" },
 ]
 
 [[package]]
@@ -1201,7 +1201,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "4.0.5"
+version = "4.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -1212,9 +1212,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
 ]
 
 [package.optional-dependencies]
@@ -1236,41 +1236,33 @@ wheels = [
 
 [[package]]
 name = "pyproject-fmt"
-version = "2.23.0"
+version = "2.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/a6/6f22eb43c2ae8d151ee51a26313df16ebd6d9e77b34c63f8fd9086f4c45a/pyproject_fmt-2.23.0.tar.gz", hash = "sha256:893215f9d9ac9deab5e549d051db6d6d8b7102724697f8a9870b17895cf6ca9c", size = 278728, upload-time = "2026-05-30T01:49:15.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/32/884b60601ef40f0f89ff35ff39b4ac2af874f09ecb5d687eb74d3ce335f9/pyproject_fmt-2.25.0.tar.gz", hash = "sha256:4a79d56e7d7d725174900092093ee33a659ad1aa1dc5db768f8e020e3783a8d1", size = 292640, upload-time = "2026-06-17T18:45:13.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/3a/c8b83d4b27f0aeb8dedb68c6388b7d05e9e805d85344deada1cefa12abd8/pyproject_fmt-2.23.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:166e614213fa8cd867218261da1147ccc4f3087370fa187b10c3df23153e5b5c", size = 5147067, upload-time = "2026-05-30T01:48:05.04Z" },
-    { url = "https://files.pythonhosted.org/packages/93/4b/a89594d446597721e0432f28688eb0f10a899e4c2f2c9fd6e028748e382a/pyproject_fmt-2.23.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:202b16f7f7ce8ad3aa54ae17a522de8743e5eefd624f03c99960ab58597d6477", size = 4888204, upload-time = "2026-05-30T01:48:07.416Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/9672a8e1ad55c7919c10b6575df8bce63cdc332ed572355606bb3f322adb/pyproject_fmt-2.23.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ddb22be85ea040ef453bd97de2827ec3d9a5d2ee1b174cdd9a748ef785ab0659", size = 5044925, upload-time = "2026-05-30T01:48:09.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/39/8f99b0e088f88a358105b823379089755c9660da24d037cd0ff5e09d36d6/pyproject_fmt-2.23.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:99d4e4b86ec8d1f20af53f16245a784dff55f03a7e2e5c57874cf562ec2a53f3", size = 5449523, upload-time = "2026-05-30T01:48:12.145Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4a/7c1abb0542e4d528d52b30ddadd745e87a110dae827c0ba8179a4a3df5e9/pyproject_fmt-2.23.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:4f34d510fddc49f523ca59065910c479b3e8343a8d3d32201d3b59b0d788c0bc", size = 5152925, upload-time = "2026-05-30T01:48:14.249Z" },
-    { url = "https://files.pythonhosted.org/packages/40/6b/c9699264d80beae249925393f9afd0e95beaa0b7c9bba69d5b925c0c0752/pyproject_fmt-2.23.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b2e7b92ac9e9d56243b10ffb61a68ea5270494efdac96310bea0996de7c11d97", size = 5040309, upload-time = "2026-05-30T01:48:16.443Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8b/27e344adf8c70137966c5e21b7766255fd8750950ce74540627dcc7c5ab7/pyproject_fmt-2.23.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0346ffb4d77804de68512ce82c3212ded49faedfe2eee6c5c27c2a0be76f23b0", size = 5617312, upload-time = "2026-05-30T01:48:18.62Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/97/fbc02877ebdb14d413ab2a1660ee098d1967cf3bb60a837828f625925eb8/pyproject_fmt-2.23.0-cp310-abi3-win_amd64.whl", hash = "sha256:bbc60a00a599b556ed9ad824a6e541d7f0854848a33d710a413bbb8dfd25d807", size = 5287553, upload-time = "2026-05-30T01:48:20.525Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/72/248d94c639ade7d6aa7e5b03f3cce1d28b597c6facacb5795bcaa8985854/pyproject_fmt-2.23.0-cp310-abi3-win_arm64.whl", hash = "sha256:3ed0e36caccbf3955dbd5a5cc83862b331acb5e07db1ef31e11f647d88dbeccc", size = 4826866, upload-time = "2026-05-30T01:48:22.273Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/b5/cc1d90322e0e376f03083952e1c65ab190cc2173fe2def1a4bddc9f2748a/pyproject_fmt-2.23.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:0a958bbe5be12aa18ad48dcb8b51ce81fabf403121f496d1f0d3c9451a77ffc9", size = 5137403, upload-time = "2026-05-30T01:48:24.353Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/82/c80ca4d5fb881016633f359d0d3f97f64eb1c186a749e9b27a37651b9d32/pyproject_fmt-2.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:40f59cf623e57463afeebfc9cd9b3e3691f87ae627cc8096c9f3edd4755fb219", size = 4884077, upload-time = "2026-05-30T01:48:26.789Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/22/f8e90dfda84449ec92f3494baf0cd98e7452754c8831fe143143a6895253/pyproject_fmt-2.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:b1fb0f5cf73e020a773a32950a496293141facfb0f918bdea54d31f1d78bb466", size = 5040761, upload-time = "2026-05-30T01:48:28.762Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/9e/0ec445447f691e60fb35e6809e563c9231a5173f5761a0f76f566d713e89/pyproject_fmt-2.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:83d0569e24891f1e19dbbe305475a294e1e04f7ebe3578286c5fb07cf763d79a", size = 5442187, upload-time = "2026-05-30T01:48:30.954Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/26/2de5e89a8a6e7f4bae66e917bc6d3e112f4e6e14c5bf3c7dd923f14c3c7b/pyproject_fmt-2.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:73a94faa18917d0103c6cb228b419484ca1d0b58a786909f8b21f0a15791ba32", size = 5036165, upload-time = "2026-05-30T01:48:32.815Z" },
-    { url = "https://files.pythonhosted.org/packages/19/fd/58d24235e4e661261f1118bb994458891a01e2779098f3d0d6c089e6b7c7/pyproject_fmt-2.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6565c7bf05ed3a737ab0ab41fd18c33c9c7ea03f049a0a2558135dbe17d72d9e", size = 5612303, upload-time = "2026-05-30T01:48:35.135Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f2/c83b2fb7a58e02fc90af4af1f2b7ffc08ab351dbbe1965c620b3ed32ff5b/pyproject_fmt-2.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:25e01dc6876fe9da0c0380f291c7234685e3214431b2dac6cc2bc62d1f896244", size = 5289697, upload-time = "2026-05-30T01:48:36.87Z" },
-    { url = "https://files.pythonhosted.org/packages/65/58/5a217161be7f7c2723fc6ccd70b249bfc1a7dea9f0acab103f7068f34c77/pyproject_fmt-2.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:e5000e3c5e0c93748e364ddeb228710c8052862f1aacfad475f0497f4f5f73cc", size = 4824665, upload-time = "2026-05-30T01:48:38.954Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/0f/5089ddf3e06765711d24a2d031cc658a84ce658bbb02ae3117b7c33501fb/pyproject_fmt-2.23.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:9bff7f42f699a7d7ae4cfd9f7c0f3638998a2d6313cb05b24de8e7e8c47a185a", size = 5138341, upload-time = "2026-05-30T01:48:40.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/5a/2abff23b627b50c222e383efa83bac5b17be6895cb7ab2628b12a56e59e7/pyproject_fmt-2.23.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ebadbbc634ac381ef9fe6c1b9fbbaa1e393e81092249e151065a44e9fa80c322", size = 4884748, upload-time = "2026-05-30T01:48:42.975Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/f2/b56f647a3f2c52c6402e07bc99776e8dbc7bf52a6d6acd9e4f209ab5c438/pyproject_fmt-2.23.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1177acf2c5e5d99d8a1bf5227036c91ab347e39cdd42a11068b3162b825c7215", size = 5040023, upload-time = "2026-05-30T01:48:44.845Z" },
-    { url = "https://files.pythonhosted.org/packages/af/68/03816e736d8b90a2872028db4439497c1893d3d5cbfc80507b30dffdb5a9/pyproject_fmt-2.23.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ad0901a7aeff0ad11c382152ce5bdccfd8103c85349526eb194cd976d38b0bca", size = 5444604, upload-time = "2026-05-30T01:48:47.17Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/d0/0611ad78ed69bacfc9eef385f6ba48869f8c62f8f0c0c9fda0db1b2edf04/pyproject_fmt-2.23.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7803f35c636591220f582bd3ffb555acfc9d86ca82ec08ce10623d0d57550de2", size = 5035994, upload-time = "2026-05-30T01:48:49Z" },
-    { url = "https://files.pythonhosted.org/packages/68/1a/8be4ec2d1e87d42f85cfa1ed0163c61af07a4d22468513d79e88ea1a6127/pyproject_fmt-2.23.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623354f81291bc884e81069792955193679a0af43d4cc1cf1af59d1eb5fa7386", size = 5614329, upload-time = "2026-05-30T01:48:51.16Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f2/461632330e991f73abfb6f62fb280a1a4d49a38fcad67ac395dd90570001/pyproject_fmt-2.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:32b299d5ee2bb5752da558dd475e44726e956111ec18c7bf16cba8d050d211b0", size = 5290888, upload-time = "2026-05-30T01:48:53.662Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/71/0ad901972d9e810aa086ee10c9c4bd96aab08c9e71ec3e2cb9cd7a83f303/pyproject_fmt-2.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7e0813432ac38e55b94f24956e51d91fc340310adbc3b96c8cfa751df31d1404", size = 4824667, upload-time = "2026-05-30T01:48:56.253Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c9/00843579b5db4b41f12042c2f09191768439121b645ebae0cca66e7e4b8f/pyproject_fmt-2.23.0-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:2df4d1a3ead6f235cd208f454b0bab0656e693cebed332612526148f7ee21324", size = 5138351, upload-time = "2026-05-30T01:48:58.255Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c1/fbd07d5b4ae9daceb19c7ee39488c4b55d57026699e30a35ab6d561b6c0a/pyproject_fmt-2.23.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:74153f08e64651206286efc6871c4da8c89360ca7f8651fe5c92cb6385f83ed9", size = 4884297, upload-time = "2026-05-30T01:49:00.1Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ab/0ecb8739125185a8cbb51fca6c7b1b74e65de09f2d8be0f8619f00ef777c/pyproject_fmt-2.23.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:c8c9cea05fbbfe7cf2be3ece0a1cae75da1ea6a0982766abf83044427ceaa26d", size = 5040815, upload-time = "2026-05-30T01:49:01.953Z" },
-    { url = "https://files.pythonhosted.org/packages/59/94/adf908f952c9c5ea298623bc29a6727347a90fc48fdcdde9cf2215c50e1a/pyproject_fmt-2.23.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:6b8d40f0b13ac4ab1a5a07f02d85df4553810201db77fc675eb61358f414d937", size = 5444585, upload-time = "2026-05-30T01:49:03.849Z" },
-    { url = "https://files.pythonhosted.org/packages/47/29/bb29305786ce9c71c51774292e268d12aa3c2ba090bd594440bcf1518f37/pyproject_fmt-2.23.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:7568110e8f51b29bed840aac910c03ac2087b8f6ee7a2254d0da25aa3fb59771", size = 5034655, upload-time = "2026-05-30T01:49:05.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/19/580d53421d10e14fda60796c3c7ee43b06cf688455d874607c5da076f46b/pyproject_fmt-2.23.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:9cee010e37fd81f9d7a81663d822b495c5044397eaa4ccedcd983c46cf50377c", size = 5613689, upload-time = "2026-05-30T01:49:07.357Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2d/4bb62fb12487101391bda3c3fcf45395e561286df16e9390eaf37af9e1e5/pyproject_fmt-2.25.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:831d973aa0946eb00afdd58208a4d5a5b6cbf08407b3dc9f5e91097d72d9f9e4", size = 5159941, upload-time = "2026-06-17T18:44:21.959Z" },
+    { url = "https://files.pythonhosted.org/packages/02/af/01b6aa6e56ab5c85a602f434b4714b35373e586124ec13077eb912bafea0/pyproject_fmt-2.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:1d5ab2d934e76a93207539f671241d38e636b09be87a6536d805d5b7349fe0a2", size = 4928556, upload-time = "2026-06-17T18:44:24.061Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bd/c80facf6f81b9ba8dc8a8b32e99b042fe89f3d2abe9f1dadbead2979a24a/pyproject_fmt-2.25.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:924bace84936ff88b3672ef68afa77c194ae81e4edb159c1b31ec04b1f174d29", size = 5084657, upload-time = "2026-06-17T18:44:25.844Z" },
+    { url = "https://files.pythonhosted.org/packages/74/63/c1faca927715d85450e783bca9bdbfe91ef9e5791c7cdd0471f74c645911/pyproject_fmt-2.25.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5dbecc097a8ac229094fde12017122c1b013364c2939f6c78fe27c9f48698d0c", size = 5474594, upload-time = "2026-06-17T18:44:27.745Z" },
+    { url = "https://files.pythonhosted.org/packages/81/9d/8505e93fa846a33943399c0f5597e3083e07a37aff574b0c2400a737009f/pyproject_fmt-2.25.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:f449bffa86570d0df4392f4b42b74b124e73acb8096bf0905102ca34bc23a6be", size = 5190335, upload-time = "2026-06-17T18:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c5/f8609bc6e507ef09f830f6046c858bfb2720c9575227ce0bc0a21b0666ce/pyproject_fmt-2.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f5e043aac3c3bdda3e74b43f1276ffc923e76e634a583d72f9069363592ab766", size = 5083998, upload-time = "2026-06-17T18:44:31.42Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8c/28ba8eab25e8f86da76044a21aa50d0fb4fcf3c4e7db357cd65a99c1a6f5/pyproject_fmt-2.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4d1baf9b8f74092259ee6fe7e24fce80bde8ac3db7ce8251fbf919f0ae0a2481", size = 5646524, upload-time = "2026-06-17T18:44:33.147Z" },
+    { url = "https://files.pythonhosted.org/packages/25/34/db9a6a540b1136736678bb8e40722a718d54dac68f2ca2e7def26234c948/pyproject_fmt-2.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e73a971ee80ba5123e893fd0cce4d0fbe590ae86f5b0e8826db740d14b715de2", size = 5317768, upload-time = "2026-06-17T18:44:34.999Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/84/67fdd4581761e385b293cc340b3497393c4e845e89a001c0c51b896be7f9/pyproject_fmt-2.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:da347f91beddb24b0f765393a12e6cbe1bee3d9448c85077e32908a88ad8953b", size = 4850474, upload-time = "2026-06-17T18:44:36.687Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/6de4b8efbbcd42a644716148446adc3949c6d182feeb6c262475e9c9d5b6/pyproject_fmt-2.25.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:b8b9e12fb2ced4bbe47c29b299ef46cb2c833f8e893da3e1cacab904a6bc75b1", size = 5157055, upload-time = "2026-06-17T18:44:38.663Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/0b03c7d089a14079ec00a6f9c37d40acb385f3b3e23de72e06af5f848502/pyproject_fmt-2.25.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c57da5044dee3a3da357eb41087e55d875d4caa2de0bdcecbbf27b101b1304ff", size = 4920642, upload-time = "2026-06-17T18:44:40.793Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/6e2fa1eee7c140822a40774ca979af6a6d40b95b36fbee976cabf456830a/pyproject_fmt-2.25.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1468922a3cbf957885559517991078ba13fc9a08b982a941482b4fbf2a76ab56", size = 5076835, upload-time = "2026-06-17T18:44:44.499Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/91/fdaecc3c7225405d6f5d30328bd823cdcf21778f8665af550090acbb0468/pyproject_fmt-2.25.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:618fd34772bab5001b5ccc1c187971f11ba78bcd50b632b20db5ebdb17aa23bb", size = 5466932, upload-time = "2026-06-17T18:44:46.897Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/0aeebcdce9addbed7844c042328e2aca58b37ee22b7e988dd69488230b93/pyproject_fmt-2.25.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:13c6965cf7e3d623c7ff02d74c3c8048ebeb3908c67c35c6a06e5d356e0fc3b3", size = 5076941, upload-time = "2026-06-17T18:44:48.633Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f5/f967b699ed4c5f4893d48239f9577db6f12ec60a881804fa43d66820ba2a/pyproject_fmt-2.25.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fe72a2686b2c159c66f66db3263fc406c1b86c93c95180ddbaaf4832103ff3a", size = 5642279, upload-time = "2026-06-17T18:44:50.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/40/53f59cd4ca8dcbf550b15f0991b440fdaa31302690a515a790e9e6ad187c/pyproject_fmt-2.25.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f94c2c5c6d93e9cc1b6fe9481082a0f8e96ae97db02fe58e01fb3b1ece6fcec", size = 5315177, upload-time = "2026-06-17T18:44:52.637Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/33/986fa9300592c368b1c438048b5ccf2f4850c0481a43a27e0fc324edd182/pyproject_fmt-2.25.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9ba368c880942f431e66f413146e96b60d3e3145c5137c435382eedaa1153660", size = 4845703, upload-time = "2026-06-17T18:44:54.683Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6e/68a0a43f4624484f47d079e493ba6f5833f60aa3edf0e4fdb35b608dc145/pyproject_fmt-2.25.0-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:84eae85ece6c8004355cbf4b40ad97ececfe53ac66f14826a1c49c6fd5fd04e1", size = 5156709, upload-time = "2026-06-17T18:44:56.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ee/d70cc4e2ec4dba73dfe44c963fe27c2f2b5eccb47b778363369d2fe71bfb/pyproject_fmt-2.25.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:a0ce847fdaabf8ffa0595034db31fe9884a2f9c8e49608166fd089059bfa27c8", size = 4920725, upload-time = "2026-06-17T18:44:58.528Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/16/43927f66f76a1833a1ae1c69659a913735bc8afce5c350103a01183bcadd/pyproject_fmt-2.25.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:401eaa6fab8265b1799e1497183f14bcc39060b47465deac85e85a25ec549452", size = 5078877, upload-time = "2026-06-17T18:45:00.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/07/2c595af5eab4008beeebdea0784dd81de1ea488f1b698855553072336158/pyproject_fmt-2.25.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:9fa1b9b49fe395270dee7d188edc51a4e4bac4da0f0316aa668e74b9c1d0aa37", size = 5467029, upload-time = "2026-06-17T18:45:02.656Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c9/f9d9e1c787d1a528d314dc9738a78952d734567d32474acbd028fc2ce922/pyproject_fmt-2.25.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:ff9f7e30b1dc6d83b668dfc02b29ff2a8c111d89a68d2efff4a86442dc23d982", size = 5078328, upload-time = "2026-06-17T18:45:04.405Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fc/a2371dced5b1540d26b9db880c242758ad0daed68e4ccec9e305cf7326d2/pyproject_fmt-2.25.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:2163f1bb4c6cd81bc93d7d666170527ff12ad8334b973c764e023f5b68ea3ece", size = 5641748, upload-time = "2026-06-17T18:45:06.405Z" },
 ]
 
 [[package]]
@@ -1284,19 +1276,21 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "1.0.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/3a/9045b0097ac58979c7c30a4fa0e673db942d4adbc7b6d439bd54ae58c441/pyrefly-1.0.0.tar.gz", hash = "sha256:5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455", size = 5677995, upload-time = "2026-05-12T20:12:46.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6", size = 13122950, upload-time = "2026-05-12T20:12:20.711Z" },
-    { url = "https://files.pythonhosted.org/packages/82/91/a3cf2a1e87d336eaa804a1e6fc93266faf6dc2a97eecdbc7eae289628022/pyrefly-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7038efc3a40f8294edee339895633cf22db268c0d434cdbcbefc34f78a9ecc3", size = 12599494, upload-time = "2026-05-12T20:12:23.495Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416", size = 12995507, upload-time = "2026-05-12T20:12:25.951Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ac/2df0899f8464c97e5d995f994c97c5cb5b0f58610432aa90d26d924e1db5/pyrefly-1.0.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c74219d8f3e63cdaa5501a0b21d1c9d37011820f9606728d0ed06f09ae86a878", size = 13947693, upload-time = "2026-05-12T20:12:29.188Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3e/b247c24321e36f04b7d51f9ccf3df93e5009e4b29939524b36ec2e17dc2a/pyrefly-1.0.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0d05543b1bb6ee6d64149eb5d6b2fb15aa72d3962d6a97abca0afaca8b0c131", size = 13925803, upload-time = "2026-05-12T20:12:31.904Z" },
-    { url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc", size = 13470398, upload-time = "2026-05-12T20:12:35.302Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/2b/6372c7dddb326223e24a46b17efd0d4bd7b4fe22c821e523157577eed2d2/pyrefly-1.0.0-py3-none-win32.whl", hash = "sha256:aa8b5d0e47080e3202a2547b39f7a5a61d2c781c712b3b67884f745ca2c759d2", size = 12222643, upload-time = "2026-05-12T20:12:38.618Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ad/1d23be700b6b2ddaeb362360c7145917a8edbbf7240ae428d40541772fce/pyrefly-1.0.0-py3-none-win_amd64.whl", hash = "sha256:c8abcb0f2082e83c890375128f9cff4aa4d3f210b85eea7b3046c1ae764e77f5", size = 13146369, upload-time = "2026-05-12T20:12:41.423Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/38/16589134f3012fd097a10dcc85771555f1a5fb76e04b682597180743af30/pyrefly-1.0.0-py3-none-win_arm64.whl", hash = "sha256:d150fa9e40e8392832be81c3bcfc0497c146674ce4d0f8e04e1ec29e775ffb8c", size = 12538326, upload-time = "2026-05-12T20:12:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]
@@ -1332,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1341,9 +1335,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1582,27 +1576,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]
@@ -1759,7 +1753,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-substitution-extensions"
-version = "2026.1.12"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -1767,9 +1761,9 @@ dependencies = [
     { name = "myst-parser" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/3e/a82aa5fed0d06161a89dc2f6971b160f837cad44f196c467fc6b2132acaa/sphinx_substitution_extensions-2026.1.12.tar.gz", hash = "sha256:25e0c6c40fbf9e1df593883da946879044a3bf8d85652c8c58f354a53575d736", size = 31676, upload-time = "2026-01-12T06:19:35.324Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/fb/6bf1b3e5bbd97d6f4632e2bb8f48518f8400cf0e4d2949f15be5a933b068/sphinx_substitution_extensions-2026.6.17.tar.gz", hash = "sha256:b7901937a43853bdaa97408ab8d73c9dc3497ec9bcf3a0c4b5fb2cce8baece13", size = 37045, upload-time = "2026-06-17T09:57:31.943Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/5e/9caa7167d2ef2b60326765150d64513be1b61b1864ad58a92683578b2776/sphinx_substitution_extensions-2026.1.12-py2.py3-none-any.whl", hash = "sha256:9152beb4f0f5cab52057681b376a473fa6b997defc85d4ac154dd12b13a3e987", size = 8766, upload-time = "2026-01-12T06:19:33.541Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e9/b8f35529c3fa1fd3efd232113c5342bef4ab0cb703a1a3beda2fcccb6392/sphinx_substitution_extensions-2026.6.17-py2.py3-none-any.whl", hash = "sha256:9971b1e402d13faaca903af894130a831218f78e8e266d36cbcddad83b7f7609", size = 10152, upload-time = "2026-06-17T09:57:30.783Z" },
 ]
 
 [[package]]
@@ -1877,11 +1871,11 @@ wheels = [
 
 [[package]]
 name = "sybil"
-version = "10.0.1"
+version = "10.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/2b/5ee5ef413b87f215c03cd08462dc341903b86707e517e20715823c984893/sybil-10.0.1.tar.gz", hash = "sha256:319eed013ebe848f8c57ce79c1ed526e506d952c778693979bc509513ae72a68", size = 80120, upload-time = "2026-03-26T08:56:30.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/50135b55ba14509654b2f624eaf7e318d654182ebe9f712fb74e98e418d0/sybil-10.1.0.tar.gz", hash = "sha256:062249c8886a0ab19e45d1c3afd5631ec806e7a95cf5153c96560f5e47756cbd", size = 82376, upload-time = "2026-06-13T09:40:44.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/f3/4f2a8069d212a33bccc88be13b5bdad61f810054f6c21c6da3aa25fb38d0/sybil-10.0.1-py3-none-any.whl", hash = "sha256:0030d8583d5ce97969397d303db1f17054f61b23f18469c0ac61f9f42735571c", size = 40316, upload-time = "2026-03-26T08:56:29.502Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fe/4094754188b52f8333ba24b377192918936597769a574a9dd8446f69e1f1/sybil-10.1.0-py3-none-any.whl", hash = "sha256:b3015f7e0ca3fe197ae67117c440710b62ea500078d4414ebd0ab804d12c9897", size = 40930, upload-time = "2026-06-13T09:40:43.139Z" },
 ]
 
 [package.optional-dependencies]
@@ -1991,27 +1985,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.48"
+version = "0.0.51"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/ad/7a6568b4a8dbb6531ef4f13cd5658e0e4fbd18b890a137b96e1ac87638d5/ty-0.0.48.tar.gz", hash = "sha256:aa54d69b755ea3f765975abdc5fe41f8daca45b1aabc57f91ddd3bd4b7e0c2de", size = 5868533, upload-time = "2026-06-10T22:36:10.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ce/352fcdba5c72ea20e5d2e46e28809cdb617575b71209d971eff2ace8e6c4/ty-0.0.51.tar.gz", hash = "sha256:b90172d46365bb9d51a7011cbb5c60cc4f514f42c86635df6c092b717f85e1ac", size = 5953151, upload-time = "2026-06-19T01:48:58.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/14/6872bdcd4b2da07c9edebafa22280020b4bc46fe0dcfaad3900cf5b7eede/ty-0.0.48-py3-none-linux_armv6l.whl", hash = "sha256:a6709c6a043524fa36735448e87c902d428033c5f3df7cdf81361ed93b99552c", size = 11810553, upload-time = "2026-06-10T22:35:40.08Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5c/5f1ee9ee82e05ec7e5456d07ee488776003e3bcc77acdf863b5b14880465/ty-0.0.48-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f52a04c3f9e464860e2ce44afa60d98079c5e09e4e4940990ebe5f3ba9cf3dff", size = 11559964, upload-time = "2026-06-10T22:36:12.816Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/15/933a57a0bdbbfa82f0c7cf884d45155628edc2d44e8afe9d8a172aafc0d7/ty-0.0.48-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cd3cb6ee735cfb544e1d6c7cabda7164fd29d1a3ded84f22f092495530faafe2", size = 10950220, upload-time = "2026-06-10T22:35:35.811Z" },
-    { url = "https://files.pythonhosted.org/packages/77/f2/12acd376cc719ebcff1d76efc1cafcc98a24c0f6fb23e730860024cdd965/ty-0.0.48-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5846c1c9e1777e60fa204d9b7c912e8db8647bdc8d4fcb176ccb3278ed96635a", size = 11485715, upload-time = "2026-06-10T22:35:53.229Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/db/b839e397f016274a175f71c53b959007ab5bb1c2928746fbb4a7a2c61153/ty-0.0.48-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:518d08a7194a5d3d07b5f459cace1e2a3a8d67c58e27b092bc948078c03fdad9", size = 11593310, upload-time = "2026-06-10T22:35:46.617Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/39/908e9c2141ff133452552b1f0b0c278b52812047ea671b59dfb064f1180c/ty-0.0.48-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bea4240fd52b1405c090c649bf1786a995f0809499e1a8bedf6a6a372f925a98", size = 12048829, upload-time = "2026-06-10T22:36:06.842Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/51/aa0e5fae345cd5fea8a8d5cfce6a900604ea42b99b3d6b7da99787e60505/ty-0.0.48-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c5241363be03c1ca0cd2b60c5ccf55a5f2803ddfa80fd61944b405fc21226c1", size = 12642932, upload-time = "2026-06-10T22:35:59.962Z" },
-    { url = "https://files.pythonhosted.org/packages/32/d0/6928525166890b04cbb9fc75d6308dbda3bdd81d1c076dade2d36c2276a6/ty-0.0.48-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e22ede258dd37a3117db0259fc80001615a6dfddc36dbb0371253f97fd7fd817", size = 12279019, upload-time = "2026-06-10T22:35:42.036Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3d/7cb614c74f8883720034ca5ee9ce3d213aff762ad87f50315b50fad705ce/ty-0.0.48-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee756f22cfc8e72c8e01c695c0b97caab6de1df1a299e7c7c6e31a6249441fed", size = 12145259, upload-time = "2026-06-10T22:35:38.02Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/44/391886e74ef7d126aeb1096fc0002a595d99ed87febfb9fe0b2b859325e6/ty-0.0.48-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:05ebfcc99da65786ba42ddb9cab9c1f2d50ad66493f512242fce40036c51fb98", size = 12339393, upload-time = "2026-06-10T22:35:55.216Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/42/dcfe9ace7cbdf6c9a242b26ed7281c692fdf054468255422b277753dd296/ty-0.0.48-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11f88996c497cb08a33fb5019ea66d096bba469d23b2fed53ee604dff5fd94ae", size = 11442355, upload-time = "2026-06-10T22:36:01.975Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/13/fbd8aabf8fc2034c70538b3ce472ada31391d5e7c86f9ea724940afdf43b/ty-0.0.48-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:70e5e4edbdec56c146f085617f085ae4c7d5dfecbefccef51e093f506af9b02e", size = 11602499, upload-time = "2026-06-10T22:36:04.41Z" },
-    { url = "https://files.pythonhosted.org/packages/64/09/44e53ac462952f8988aa27a5c141c2f3535fc4fcb68f571d80baf73939e4/ty-0.0.48-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d420c3478f338511e47a2987052e5099b7f67aa0ab725e5e1e2f5658d11099bd", size = 11711851, upload-time = "2026-06-10T22:35:44.517Z" },
-    { url = "https://files.pythonhosted.org/packages/89/15/b1b22a01094ce9b2a5ecaf6fe1530490dc25b0260551d702e881b2601014/ty-0.0.48-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0bf036e2e3a359c1e83883a46a4d2076617511d7329fe5421c7d158f28e19615", size = 12230497, upload-time = "2026-06-10T22:35:57.714Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e9/9bba0e7fcc3a5058d7fa55be410356991925cc0f6546ccd1eb0821aee48f/ty-0.0.48-py3-none-win32.whl", hash = "sha256:19ad4acd4347ca3e206e7455c2a05fba228e1b3186463517bcb783f88885ff78", size = 11048763, upload-time = "2026-06-10T22:35:49.049Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/6a/71d815058affbbc26d43538002c74203cf6a72a4b342981fc13324e64412/ty-0.0.48-py3-none-win_amd64.whl", hash = "sha256:1f496d799abab6e5a26c901a049163f171aa1b40c8e418cdf76adf3444d1b0db", size = 12188589, upload-time = "2026-06-10T22:36:08.938Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/fe/a8f8ad81612ab7f75a170c70710f8d2c4ada39e86b827a4e524086f50c24/ty-0.0.48-py3-none-win_arm64.whl", hash = "sha256:77c94e4484897c3a184821cd56274b71f1c001663331f9c1ba06ac889633bff6", size = 11542770, upload-time = "2026-06-10T22:35:51.122Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/8f/8fe7cab79a45320b2cdcd602f16d44c8108d2f418ff7ec316c6212f1f0cc/ty-0.0.51-py3-none-linux_armv6l.whl", hash = "sha256:947986bd82d324b3a5c58ce03f1dad160cdf36443d3e8f64b3484b861ba9bc64", size = 11884805, upload-time = "2026-06-19T01:48:20.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b4/56fdc39a3f44c0564fd157e1e59e1f9c3fc5ba57ae4472ded85c67c63d74/ty-0.0.51-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25a5b31e6f23fd5dc63ad29087ded09932409e4154e2fe07bbaed015035990bb", size = 11633593, upload-time = "2026-06-19T01:48:22.998Z" },
+    { url = "https://files.pythonhosted.org/packages/33/57/136e83f24fc04f5afdcabff42f40fa27eae5ac3f0e3f12627d072a55f679/ty-0.0.51-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2faed19a8f1505370de071c008df52a994fc03a204f3267c3a33a32ca26f854f", size = 11063076, upload-time = "2026-06-19T01:48:25.223Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f8/5d32f0df5692446440ab781b9b119aa3e0c0dbfa78c583fe9be8417d54fa/ty-0.0.51-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08adbe53fb8bc9e7f00e89bf1d3c875a02cda76d83f109d2e6ab1ff35a7bfa8c", size = 11579542, upload-time = "2026-06-19T01:48:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0c/4f54ef338e9623886809ecd508931b0cd5b3aba1e591586a2f6aeaa8bd11/ty-0.0.51-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dc5e93695ab5dcbf1eef663aee60ec23a413547cc9cb06adcb0d842e9166bd0f", size = 11676189, upload-time = "2026-06-19T01:48:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/56/27/31729066f9b9d3596941edaf267894eefc0b30df4518f003dba5f7276258/ty-0.0.51-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd92913bc90d1705ef9391ff8c6822b61e2e827fa295eb30bf0dfabcf815645", size = 12188154, upload-time = "2026-06-19T01:48:31.68Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/38/d4301aa12d2283c7130908baf1417a37dfe3e10f5669cb4ce2853c2540b4/ty-0.0.51-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:429a997394dac73870d71b87cc90efc54da3efaf319e72ca18aeef35a78aef90", size = 12780597, upload-time = "2026-06-19T01:48:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/52/4b2e67e53f126d39abe201bd2299e467e27463a284e965ad195cbc217fa0/ty-0.0.51-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62d94f06e8c317e89b6884f2bde443040e596b88c7c79bd944c84c105b06257a", size = 12491115, upload-time = "2026-06-19T01:48:36.169Z" },
+    { url = "https://files.pythonhosted.org/packages/74/50/aabfe55c132ebe72b4d639cbf772d931e11b0990d29c1f691922b6ccabc1/ty-0.0.51-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8f52952cff665bc52a36147e610c10f5699d30007d7a14ab7f345cff93476ff", size = 12230135, upload-time = "2026-06-19T01:48:38.445Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1b/9aa428052dbed91c50919cd080426a313cf20ce14c6bfe2b71345e548671/ty-0.0.51-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c1bd1355aee86af01e4e21b0bc16fc460fb05905761f0d8b8d70841de0feade8", size = 12468123, upload-time = "2026-06-19T01:48:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5a/f6ce69f2575259386c950c40e02578d0902760cb61f95045e9971182c24e/ty-0.0.51-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:79d1877e93460f936bc10ed1a31525702b7ce51075763ccba993be17f0b9e905", size = 11541672, upload-time = "2026-06-19T01:48:42.635Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3a/2af48924a683e959e95e5cc4dc88e5a8595206a0812b869032b95196f2b0/ty-0.0.51-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cc233a6235fb23e2a44b14731a10043e37ba2f30f2c361cf49ad3633c5b9da9c", size = 11694015, upload-time = "2026-06-19T01:48:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/12/899875d8a60b198c8121cb92ce18e18cc072d23ca2130fcdaa176383ef72/ty-0.0.51-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bc7459348a253247bbfb2669a021e614281b86bbea24c36112b8a6e1a2499a16", size = 11832856, upload-time = "2026-06-19T01:48:47.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a2/88f681d826d97cc96ef9f6cadd4935f775758944cee07340aa46113bce28/ty-0.0.51-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49a21237f6fd1de56beaff0a3e85fe022a09a3401e67e3abec41ce838a5d4d2e", size = 12333449, upload-time = "2026-06-19T01:48:49.091Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/535a4163b4452c6978c31fedfd7b5803cf3a2253e9455cde350f86638d6a/ty-0.0.51-py3-none-win32.whl", hash = "sha256:61b4b6a003c3ebe53a63a1125c9b6542aa01bc1b6c9a235d01ee328d000d61a9", size = 11177338, upload-time = "2026-06-19T01:48:51.433Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4d/2334fbb74291a20129fa7aaa8f789619ec9b6883b27f997b8baa27e4674f/ty-0.0.51-py3-none-win_amd64.whl", hash = "sha256:608d417cd1eaf79bcbd713d9830d5e3db9d57ec225c3af3e4ac9a9ff66b45d70", size = 12325675, upload-time = "2026-06-19T01:48:53.774Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b5/d49096cd5f3694becb86a5a6ccd0f229ead695fc7430d6bc4dd0a104c6fe/ty-0.0.51-py3-none-win_arm64.whl", hash = "sha256:62ced5e380284f12b2dc4802a3e4ed3dac39913fc6719afde7978814a4c7f169", size = 11657350, upload-time = "2026-06-19T01:48:55.904Z" },
 ]
 
 [[package]]
@@ -2167,37 +2161,37 @@ requires-dist = [
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.20.1" },
-    { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.4" },
+    { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.5" },
     { name = "pydocstringformatter", marker = "extra == 'dev'", specifier = "==0.7.5" },
-    { name = "pylint", extras = ["spelling"], marker = "extra == 'dev'", specifier = "==4.0.5" },
+    { name = "pylint", extras = ["spelling"], marker = "extra == 'dev'", specifier = "==4.0.6" },
     { name = "pylint-per-file-ignores", marker = "extra == 'dev'", specifier = "==3.2.1" },
-    { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.23.0" },
-    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==1.0.0" },
+    { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.25.0" },
+    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==1.1.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.410" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-beartype-tests", marker = "extra == 'dev'", specifier = "==2026.4.26" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "respx", specifier = ">=0.22.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.16" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.18" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
     { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = "==9.1.0" },
     { name = "sphinx-copybutton", marker = "extra == 'dev'", specifier = "==0.5.2" },
     { name = "sphinx-lint", marker = "extra == 'dev'", specifier = "==1.0.2" },
     { name = "sphinx-pyproject", marker = "extra == 'dev'", specifier = "==0.3.0" },
-    { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
+    { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.6.17" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
     { name = "sphinxcontrib-towncrier", marker = "extra == 'dev'", specifier = "==0.5.0a0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.6.8.post1" },
-    { name = "sybil", extras = ["pytest"], marker = "extra == 'dev'", specifier = "==10.0.1" },
+    { name = "sybil", extras = ["pytest"], marker = "extra == 'dev'", specifier = "==10.1.0" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.48" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.51" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.25.2" },
+    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.26.1" },
 ]
 provides-extras = ["dev", "release"]
 
@@ -2221,18 +2215,18 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.25.2"
+version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/41/8987d546e3101cc76748b2f1b0ccda58e244773ef5124d39e7e749e3d6e4/zizmor-1.25.2.tar.gz", hash = "sha256:f26ffeb16659c8922c7b08203ca5a4f8bf5e1a7e8d190734961c40877cf778ea", size = 517794, upload-time = "2026-05-16T06:28:43.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a0/a29b38e24981b4bb41db4f292b2c9fb9ddf8b05d6b724abddd7bd108b621/zizmor-1.26.1.tar.gz", hash = "sha256:0c2cc575007a4db99d89d5acc6120cfa7b61504bc2394c3b50af348c73f1916e", size = 535275, upload-time = "2026-06-21T02:47:21.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/bd/84108a92ccbfda0d28efc11f382997c7a767b58863bf4a550634b8cf0211/zizmor-1.25.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:17cc8cfd9d472e8b11945a869c198d25cfdf4a33f36fa7a1f9674099f5fb509d", size = 9115548, upload-time = "2026-05-16T06:28:33.591Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c0/66453a2553a66286a96ca32d75e3e6bcc94ce7f907cd5f8c2c3fce55315e/zizmor-1.25.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d3e301eb4465e2da77857cf01ab4ef0184cf3818e826800b270ab01ae7338977", size = 8665071, upload-time = "2026-05-16T06:28:30.861Z" },
-    { url = "https://files.pythonhosted.org/packages/52/3e/d60939d1cc4907c0d021a7c46362aab5e8045550bb09157d56c070e43568/zizmor-1.25.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:cf64374149b567c9373228b76c8e77a389b4071899f84b82c36ee50fab894e79", size = 8842884, upload-time = "2026-05-16T06:28:26.041Z" },
-    { url = "https://files.pythonhosted.org/packages/46/82/f3e8d9b6d941194f2558591b449c106d46a16ea566b95eccff3a83bf6acc/zizmor-1.25.2-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0beba1601be08bd00c9277e6ed4b026e125b26b379d86d6d98eb708409b3050d", size = 8449741, upload-time = "2026-05-16T06:28:45.424Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/13/445bc98acc2c976d6b8f8ca59b9c09f055adb5ffb3445d99af8ff7efcb4f/zizmor-1.25.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c4246f1344d8dbeffc044d7bb11b131773a7db7eb57d9073c45942dfd3543a1f", size = 9285184, upload-time = "2026-05-16T06:28:39.21Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/78/fc7717c706bde7531b2fde12003994fbc04c47ab4f91aa6ca9b3b24b30fd/zizmor-1.25.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dbb1b5c85b8de8eaa0227c6620f06c8e4fbd0a4da2086e218bc225c0bef0923d", size = 8886579, upload-time = "2026-05-16T06:28:51.384Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/bc/a46f11377cdc145c625d62d88c30fead56f9d29bc31652069a1a0eaed6c2/zizmor-1.25.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d670a1e2f00b3cd56febd145bc1a0b2c4caf1cbe5dad8128721843fa877e2d2e", size = 8413576, upload-time = "2026-05-16T06:28:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/3b/0fd93b77171c8f229e8e1304eecc9931bf3009f722c57967d545d9f151b6/zizmor-1.25.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b75c84d7387389f95edadbe859fb2aaf0a360c5b080932cc53e92ae1db6f09ef", size = 9378162, upload-time = "2026-05-16T06:28:41.999Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/3f/dcb85fb9a0d87794847f9043f9db9bb4d274cf4b8077604bc13850c8fdb4/zizmor-1.25.2-py3-none-win32.whl", hash = "sha256:aa9f4c43b499c55339c3ef2e885133c5017cd9a18d76d9335541203cfa5ae1e7", size = 7548509, upload-time = "2026-05-16T06:28:28.828Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/81/1cb088098bd53f9b910098b0c19d06dc587acf328a170ef8afd1cd93b482/zizmor-1.25.2-py3-none-win_amd64.whl", hash = "sha256:af55bd9bd119ea8cbce2a7addc3922503019de32c1fe31106d70b3dc77d77908", size = 8609822, upload-time = "2026-05-16T06:28:48.078Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a9/2f47f7db8db9491025e00a7f1a0f25d32b642c0285b2fe070ac63e679b47/zizmor-1.26.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7ea21ca959c8e888de238fee81d73a1fdf89a82067eac75b8f1acdbd23e2eeaf", size = 9086061, upload-time = "2026-06-21T02:46:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/58/92/cf6801f01e1d65cbda89a2e2926ea42caf1daad9ffa3f1fc88e4c68f48a9/zizmor-1.26.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:78083b495593f8b0b9dec14036a0836a5afcddda8a40738336ff4e399476b741", size = 8626865, upload-time = "2026-06-21T02:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b1/ff38fc2921f1fb13244bb3a3642c4b45ecf3946c279942aafcb5dbf55a57/zizmor-1.26.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:bb7ebbe565a3742eb49a590352127ad549bb122b9b4ff9424ebab7525fa3b6b6", size = 8843965, upload-time = "2026-06-21T02:47:03.318Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/06/c07fd0eeef0427d93e99d552d5386526fbcd0bf05fc95cd37bdc6229fccb/zizmor-1.26.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:d3049010b6bd6f849413b6d20c28e0c677b90e0a5b2bc73cbee7f7bd86dc5828", size = 8386985, upload-time = "2026-06-21T02:47:05.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/61ab13d45d6ce57ef5a08bb3246981f62e30bb4938098b17bb7b88110b79/zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6a958d8a0941d7e1d0de8436670b5cb7fc64c8028b4d16e3f519ccc77f953cef", size = 9257232, upload-time = "2026-06-21T02:47:07.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ad/bd74a96cb02045414ec5b573cd97ff3b82a97fd0bd6658f93c36a011c439/zizmor-1.26.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d2744cdf944436ca7a009ae8b626a017a40381ec990216abd6cf6b8beb23323a", size = 8873798, upload-time = "2026-06-21T02:47:10.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7e/fb3d608ee11e2f619d43ad93bab46eb7b32769fa82b1d86fd23f27c2585b/zizmor-1.26.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:44099f426af9da750ff9f548a0084e11d7d83e0158fe1a2778672398d728efdd", size = 8350857, upload-time = "2026-06-21T02:47:12.748Z" },
+    { url = "https://files.pythonhosted.org/packages/27/cc/82d7a838c2d490071555c364f90eb851044b3eeefc1d68612179a2cd1ae5/zizmor-1.26.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8313cc264dec792f00a7328eb7c8e89e7d62d54f950fc897d1e6a5a6e5762203", size = 9351148, upload-time = "2026-06-21T02:47:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ee/d2a2301f30b9e1bf0d721bfd31739acd71e048757f9ba79279583eb30ac0/zizmor-1.26.1-py3-none-win32.whl", hash = "sha256:c96d7787d69fb298eae939e00dfdf7f534d7dfbd9cc17ab442c0650a56851415", size = 7531021, upload-time = "2026-06-21T02:47:17.247Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/ad561f3a5057d3c0f152002e180a3a5745e72ea9d69bf66450ef9f5d3fe5/zizmor-1.26.1-py3-none-win_amd64.whl", hash = "sha256:0a05acf6068609fb6df3b137276cf18a686226a1e0e207941cb34a85929f16cf", size = 8616584, upload-time = "2026-06-21T02:47:19.094Z" },
 ]


### PR DESCRIPTION
Closes #228.

Adds support for matching requests on their body via WireMock `bodyPatterns`, so two requests to the same method and URL can return different responses based on their bodies. Supported matchers are `equalToJson` (honouring `ignoreArrayOrder` and `ignoreExtraElements`, accepting either a JSON value or a JSON string), `contains`, and `equalTo`, implemented as a custom respx `Pattern` with no new runtime dependencies. The change includes 26 new tests at 100% coverage, README and changelog updates, and a `uv.lock`/`pyproject.toml` sync that the repo's own pre-commit hooks required. `matchesJsonPath` is deliberately deferred because it needs an untyped JSONPath engine that clashes with this repo's strict type-checking config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New request-routing behavior is non-trivial JSON matching and unsupported `bodyPatterns` types are skipped rather than failing, so WireMock parity edge cases could surprise tests until exercised.
> 
> **Overview**
> Adds **WireMock `bodyPatterns`** so stubs can distinguish requests that share method and URL by body, wiring matchers into **respx** via a custom `_BodyPattern` on each route.
> 
> Supported matchers are **`equalToJson`** (with `ignoreArrayOrder` / `ignoreExtraElements`, object or JSON string expectations), **`contains`**, and **`equalTo`**. Multiple patterns on one stub must all match. JSON comparison is implemented in-library (no new runtime deps). README, a newsfragment, and a large pytest suite cover the behavior; dev-tool versions in `uv.lock` / `pyproject.toml` were bumped as part of the same change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496e1f70365a717eda954fc7a1bda6b121c1c5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->