### PR TITLE
Support additional WireMock response fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,8 @@ Supported stub features
   ``ignoreArrayOrder`` and ``ignoreExtraElements``), ``contains`` and
   ``equalTo``. This lets two requests to the same method and URL return
   different responses based on their bodies.
-- **Response**: ``status``, ``headers``, ``jsonBody``, ``body``
+- **Response**: ``status``, ``statusMessage``, single- or multi-value
+  ``headers``, ``jsonBody``, ``body``, ``base64Body``
 
 Full documentation
 ------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,7 +65,8 @@ Supported stub features
 
 - **Request matching**: ``method``, ``urlPath`` (exact), ``urlPathPattern`` (regex)
 - **Query parameters**: ``queryParameters`` with ``equalTo``
-- **Response**: ``status``, ``headers``, ``jsonBody``, ``body``
+- **Response**: ``status``, ``statusMessage``, single- or multi-value
+  ``headers``, ``jsonBody``, ``body``, ``base64Body``
 
 Reference
 ---------

--- a/newsfragments/272.change
+++ b/newsfragments/272.change
@@ -1,0 +1,2 @@
+Add support for Base64-encoded response bodies, custom status messages and
+multi-value response headers in WireMock stubs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,7 @@ ignore_names = [
     "autoclass_content",
     "autodoc_member_order",
     "base_url",
+    "base64Body",
     # TypedDict fields accessed via string keys (not attribute access)
     "body",
     "bodyPatterns",
@@ -343,6 +344,7 @@ ignore_names = [
     "rst_prolog",
     "source_suffix",
     "spelling_word_list_filename",
+    "statusMessage",
     "templates_path",
     "towncrier_draft_autoversion_mode",
     "towncrier_draft_include_empty",

--- a/src/wiremock_mock/__init__.py
+++ b/src/wiremock_mock/__init__.py
@@ -1,5 +1,6 @@
 """Package for serving WireMock stubs as a mock with respx."""
 
+import base64
 import json
 import re
 from collections.abc import Callable
@@ -31,9 +32,11 @@ class _ResponseSpec(TypedDict, total=False):
     """A WireMock response specification."""
 
     status: object
+    statusMessage: object
     headers: object
     jsonBody: object
     body: object
+    base64Body: object
 
 
 def _coerce_json(*, value: object) -> object:
@@ -341,6 +344,35 @@ def _build_path_pattern(
     return re.compile(pattern=full_pattern)
 
 
+def _build_response_headers(*, headers_raw: object) -> list[tuple[str, str]]:
+    """Build HTTPX headers from a WireMock response header mapping."""
+    headers: list[tuple[str, str]] = []
+    if not isinstance(headers_raw, dict):
+        return headers
+    for name, value in cast("dict[object, object]", headers_raw).items():
+        if not isinstance(name, str):
+            continue
+        match value:
+            case str() as header_value:
+                headers.append((name, header_value))
+            case list():
+                headers.extend(
+                    (name, header_value)
+                    for header_value in cast("list[object]", value)
+                    if isinstance(header_value, str)
+                )
+            case _:
+                pass
+    return headers
+
+
+def _build_response_extensions(*, status_message: object) -> dict[str, object]:
+    """Build HTTPX extensions for WireMock response metadata."""
+    if isinstance(status_message, str):
+        return {"reason_phrase": status_message.encode()}
+    return {}
+
+
 def _build_response(
     *,
     response_spec: _ResponseSpec,
@@ -352,11 +384,9 @@ def _build_response(
         case _:
             status = 200
 
-    headers_raw = response_spec.get("headers")
-    headers: dict[str, str] = (
-        cast("dict[str, str]", headers_raw)
-        if isinstance(headers_raw, dict)
-        else {}
+    headers = _build_response_headers(headers_raw=response_spec.get("headers"))
+    extensions = _build_response_extensions(
+        status_message=response_spec.get("statusMessage")
     )
 
     json_body = response_spec.get("jsonBody")
@@ -365,7 +395,19 @@ def _build_response(
             status_code=status,
             headers=headers,
             json=json_body,
+            extensions=extensions,
         )
+
+    match response_spec.get("base64Body"):
+        case str() as base64_body:
+            return httpx.Response(
+                status_code=status,
+                headers=headers,
+                content=base64.b64decode(s=base64_body, validate=True),
+                extensions=extensions,
+            )
+        case _:
+            pass
 
     match response_spec.get("body"):
         case bytes() as b:
@@ -373,23 +415,27 @@ def _build_response(
                 status_code=status,
                 headers=headers,
                 content=b,
+                extensions=extensions,
             )
         case str() as s:
             return httpx.Response(
                 status_code=status,
                 headers=headers,
                 content=s.encode(),
+                extensions=extensions,
             )
         case None:
             return httpx.Response(
                 status_code=status,
                 headers=headers,
+                extensions=extensions,
             )
         case other:
             return httpx.Response(
                 status_code=status,
                 headers=headers,
                 content=str(object=other).encode(),
+                extensions=extensions,
             )
 
 
@@ -414,7 +460,8 @@ def add_wiremock_to_respx(
     stub must all match, letting two requests to the same method and URL
     return different responses based on their bodies.
 
-    Response uses status, headers, and ``jsonBody`` from each stub.
+    Response supports ``status``, ``statusMessage``, ``headers``,
+    ``jsonBody``, ``body`` and ``base64Body`` from each stub.
 
     :param mock_obj: The respx MockRouter or Router to add routes to.
     :param stubs: WireMock stubs dict with ``mappings`` array (e.g. from

--- a/tests/test_add_wiremock_to_respx.py
+++ b/tests/test_add_wiremock_to_respx.py
@@ -217,6 +217,59 @@ def test_add_wiremock_to_respx_body_bytes_response() -> None:
         assert response.content == b"binary data"
 
 
+def test_add_wiremock_to_respx_base64_body_response() -> None:
+    """Add_wiremock_to_respx decodes a WireMock ``base64Body``."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {"method": "GET", "urlPath": "/v1/bin"},
+                "response": {
+                    "status": 200,
+                    "base64Body": "YmluYXJ5AGRhdGE=",
+                },
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.get(url=f"{BASE_URL}/v1/bin")
+        assert response.content == b"binary\x00data"
+
+
+def test_add_wiremock_to_respx_response_metadata() -> None:
+    """Status messages and single or repeated headers are returned."""
+    stubs: dict[str, Any] = {
+        "mappings": [
+            {
+                "request": {"method": "GET", "urlPath": "/v1/created"},
+                "response": {
+                    "status": 201,
+                    "statusMessage": "Created for test",
+                    "headers": {
+                        "X-Single": "one",
+                        "Set-Cookie": ["first=1", "second=2"],
+                        "X-Partly-Valid": ["included", 3],
+                        "X-Invalid": 4,
+                        5: "invalid-name",
+                    },
+                },
+            },
+        ],
+    }
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as m:
+        add_wiremock_to_respx(mock_obj=m, stubs=stubs, base_url=BASE_URL)
+        response = httpx.get(url=f"{BASE_URL}/v1/created")
+        assert response.status_code == HTTPStatus.CREATED
+        assert response.reason_phrase == "Created for test"
+        assert response.headers["X-Single"] == "one"
+        assert response.headers.get_list(key="Set-Cookie") == [
+            "first=1",
+            "second=2",
+        ]
+        assert response.headers.get_list(key="X-Partly-Valid") == ["included"]
+        assert "X-Invalid" not in response.headers
+
+
 def test_add_wiremock_to_respx_body_non_string_response() -> None:
     """Add_wiremock_to_respx converts non-str/bytes body via str()."""
     stubs: dict[str, Any] = {
@@ -941,7 +994,9 @@ def test_add_wiremock_to_respx_invalid_status_and_headers() -> None:
                 "request": {"method": "GET", "urlPath": "/v1/edge"},
                 "response": {
                     "status": "invalid",
+                    "statusMessage": 1,
                     "headers": "not-a-dict",
+                    "base64Body": 2,
                     "jsonBody": {"ok": True},
                 },
             },


### PR DESCRIPTION
## Summary

Adds WireMock `base64Body` decoding and custom `statusMessage` reason phrases to respx responses.
Preserves repeated response headers such as multiple `Set-Cookie` values while filtering malformed values.
Updates tests, supported-feature documentation, typing/lint configuration, and the changelog fragment.
Closes #272.

## Validation

- `pytest --cov` — 47 passed with 100% coverage
- Ruff, mypy, Pyright, ty, and Pyrefly
- Sphinx warning-as-error build and Towncrier draft build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mock response construction in tests; no auth or production runtime paths, with broad test coverage for new and invalid fields.
> 
> **Overview**
> Extends WireMock stub **response** handling so mocked `httpx` responses better match real WireMock exports.
> 
> **`base64Body`** is decoded (with validation) into response content when present; **`jsonBody`** still wins if both are set. **`statusMessage`** maps to HTTPX’s `reason_phrase` extension so `response.reason_phrase` reflects the stub. **Headers** are built as repeated name/value pairs so list-valued headers (e.g. multiple `Set-Cookie`) are preserved; non-string header names/values are skipped.
> 
> Docs and the supported-features list are updated; tests cover the new fields and invalid metadata falling back safely when `jsonBody` is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19673c600bbaf3562bb4c5ae26c17dc4a8360573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->