### PR TITLE
Configure mypy to respect gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,6 +370,7 @@ max_supported_python = "3.14"
 [tool.mypy]
 files = [ "." ]
 exclude = [ "build" ]
+exclude_gitignore = true
 follow_untyped_imports = true
 strict = true
 plugins = [ "mypy_strict_kwargs" ]


### PR DESCRIPTION
## Summary

- configure mypy with `exclude_gitignore = true`
- prevent files ignored by Git from being included in mypy discovery

## Impact

Mypy will respect the project's `.gitignore` rules when discovering files. This avoids type-checking generated, local, or otherwise ignored files.

## Validation

- formatted and parsed `pyproject.toml` with `pyproject-fmt`
- verified the branch diff is exactly one added line in `pyproject.toml`
- ran Git whitespace validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line mypy tooling config change with no runtime, security, or application logic impact.
> 
> **Overview**
> Configures mypy with `exclude_gitignore = true` so file discovery skips paths ignored by Git.
> 
> This keeps type-checking focused on tracked project files and avoids scanning generated, local, or otherwise ignored paths when mypy runs over `.`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a98ba3d8d6188e2e90817c71e53157fc2f91a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->